### PR TITLE
Add slack invite link

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -31,7 +31,7 @@
                         <li><a href="http://kroxylicious.io/kroxylicious">Kroxylicious Documentation</a></li>
                         <li><a href="https://github.com/kroxylicious/design">Design & Discussion</a></li>
                         <li><a href="https://github.com/kroxylicious/kroxylicious/blob/main/LICENSE">License</a></li>
-                        <li><a href="https://kroxylicious.slack.com">Community & Development chat via Slack</a></li>
+                        <li><a href="https://kroxylicious.slack.com">Community & Development chat via Slack</a> (<a href="https://join.slack.com/t/kroxylicious/shared_invite/zt-1rzjijq6d-x7At3bfPiPqFEqc9RmNhYA">invitation</a>)</li>
                         <li><a href="acknowledgements.html">Acknowledgements</a></li>
                     </ul>
                 </div>


### PR DESCRIPTION
Slack is invite only. This link never expires but only works for 400 invites.