### PR TITLE
make footer stick to the bottom of the page on all screen sizes

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer class="pt-4 pt-md-5 pb-0 mt-5 bg-body-tertiary">
+<footer class="pt-4 pt-md-5 pb-0 mt-md-auto mt-5 bg-body-tertiary">
     <div class="container py-3 py-md-5 px-4 px-md-3 text-body-secondary">
         <div class="row krx-footer-links justify-content-between">
             <div class="col-lg-4 mb-3">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.2/js/bootstrap.bundle.min.js" integrity="sha512-X/YkDZyjTf4wyc2Vy16YGCPHwAY8rZJY+POgokZjQB2mhIRFJCckEGc6YyX9eNsPfn0PzThEuNs+uaomE5CO6A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     {% seo %}
 </head>
-<body data-bs-theme="light">
+<body class="d-flex flex-column vh-100" data-bs-theme="light">
 {% include nav.html %}
 <div class="container-fluid" data-bs-theme="light">
     {{ content }}


### PR DESCRIPTION
On large screens the footer does not stick to the bottom of the browser window.
![image](https://github.com/kroxylicious/kroxylicious.github.io/assets/15976368/a959c429-336e-4992-9b35-879b243ca9c2)

This PR fixes that issue, while retaining the positioning on smaller screens and mobile devices.