### PR TITLE
Fixes for GitHub Actions workflow and development work

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,5 +1,5 @@
 # Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+name: Deploy site with Jekyll
 
 on:
   # Runs on pushes targeting the default branch
@@ -28,20 +28,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.2' # Not needed with a .ruby-version file
+          cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         uses: actions/configure-pages@v3
-      - name: Download Bootstrap 5 dependencies
-        run: |
-          wget "https://github.com/twbs/bootstrap/archive/v5.3.2.zip" && \
-          unzip v5.3.2.zip -d ./_sass && mkdir ./_sass/bootstrap && \
-          mv ./_sass/bootstrap-5.3.2/scss ./_sass/bootstrap/scss && \
-          rm v5.3.2.zip && rm -r ./_sass/bootstrap-5.3.2
+      - name: Install rake
+        run: gem install rake
+      - name: Update Bundler and Setup Jekyll
+        run: bundle install && bundle update --bundler
+      - name: Download Bootstrap 5 SCSS Sources
+        run: ./bootstrap_setup.sh
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
-        with:
-          source: ./
-          destination: ./_site
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
       - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v2
 
   # Deployment job

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,9 +9,11 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
+    eventmachine (1.2.7-java)
+    eventmachine (1.2.7-x64-mingw32)
     ffi (1.16.3)
     forwardable-extended (2.6.0)
-    google-protobuf (3.25.0-arm64-darwin)
+    google-protobuf (3.25.0)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -51,21 +53,37 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (5.0.3)
+    rake (13.1.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.6)
     rouge (4.2.0)
     safe_yaml (1.0.5)
+    sass-embedded (1.69.5)
+      google-protobuf (~> 3.23)
+      rake (>= 13.0.0)
     sass-embedded (1.69.5-arm64-darwin)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x64-mingw32)
+      google-protobuf (~> 3.23)
+    sass-embedded (1.69.5-x86_64-linux-gnu)
       google-protobuf (~> 3.23)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2023.3)
+      tzinfo (>= 1.0.0)
     unicode-display_width (2.5.0)
+    wdm (0.1.1)
     webrick (1.8.1)
 
 PLATFORMS
   arm64-darwin-22
+  java
+  x64-mingw32
+  x86_64-linux
 
 DEPENDENCIES
   http_parser.rb (~> 0.6.0)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We don't use the Bootstrap 5 ruby gem here, as it runs on a
 
 ### Running Locally
 
-To run the site locally, you'll first need to download the Bootstrap 5 Sass sources by running [local_setup.sh](local_setup.sh).
+To run the site locally, you'll first need to download the Bootstrap 5 Sass sources by running [bootstrap_setup.sh](bootstrap_setup.sh).
 
 Then install the site's prerequisites by running this:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## What?
 
-This is the repo containing the kroxylicious.io website. The site runs on Jekyll, so you'll need to ensure you have the [prerequisites](https://jekyllrb.com/docs/) installed to try it locally.
+This is the repo containing the kroxylicious.io website.
+The site runs on Jekyll, so you'll need to ensure you have the [prerequisites](https://jekyllrb.com/docs/) installed to try it locally.
+You'll also need to ensure you have Ruby 3.2+ installed, along with the latest versions of Rake and Bundler for your Ruby distribution.
 
 ## Key Files
 - [Gemfile](Gemfile) - required ruby gems for building and serving the site
@@ -12,7 +14,7 @@ This is the repo containing the kroxylicious.io website. The site runs on Jekyll
 
 ## Development
 
-Built with Jekyll and Bootstrap 5
+Built with Jekyll, Bootstrap 5, and Ruby 3.2
 
 There is a GitHub action that builds and deploys the HTML/CSS
 to the `gh-pages` branch on push to `main`.

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -28,7 +28,7 @@
             <div class="vr d-none d-lg-flex h-100 text-white"></div>
           </li>
           <li class="nav-item col-6 col-lg-auto">
-            <a class="nav-link krx-nav-link py-2 px-0 px-lg-4" href="{{ '/kroxylicious' | absolute_url }}">
+            <a class="nav-link krx-nav-link py-2 px-0 px-lg-4" href="{{ '/kroxylicious' | relative_url }}">
               Docs
             </a>
           </li>

--- a/bootstrap_setup.sh
+++ b/bootstrap_setup.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
 
-export BOOTSTRAP_VERSION="v5.3.2"
+export BOOTSTRAP_VERSION="5.3.2"
 
 # download the full Bootstrap 5 sources (including JS)
-echo "Downloading Bootstrap $BOOTSTRAP_VERSION sources from GitHub..."
-wget "https://github.com/twbs/bootstrap/archive/$BOOTSTRAP_VERSION.zip"
+echo "Downloading Bootstrap v$BOOTSTRAP_VERSION sources from GitHub..."
+wget "https://github.com/twbs/bootstrap/archive/v$BOOTSTRAP_VERSION.zip"
 
 # unpack the sources into the _sass/ directory
 echo "Unpacking sources..."
-unzip "$BOOTSTRAP_VERSION.zip" -d ./_sass
+unzip "v$BOOTSTRAP_VERSION.zip" -d ./_sass
 
 # make a directory to put the Bootstrap 5 Sass sources into
 mkdir ./_sass/bootstrap
 
 # move the Sass sources to your new directory
-mv ./_sass/bootstrap-5.3.2/scss ./_sass/bootstrap/scss
+mv "./_sass/bootstrap-$BOOTSTRAP_VERSION/scss" ./_sass/bootstrap/scss
 
 # delete all the other Bootstrap sources (i.e. except the Sass ones, which we moved)
 echo "Cleaning up..."
-rm -r ./_sass/bootstrap-5.3.2
+rm -r "./_sass/bootstrap-$BOOTSTRAP_VERSION"
 
 # delete the downloaded zip
-rm v5.3.2.zip
+rm "v$BOOTSTRAP_VERSION.zip"
 
 echo "Done!"

--- a/bootstrap_setup.sh
+++ b/bootstrap_setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+export BOOTSTRAP_VERSION="v5.3.2"
+
+# download the full Bootstrap 5 sources (including JS)
+echo "Downloading Bootstrap $BOOTSTRAP_VERSION sources from GitHub..."
+wget "https://github.com/twbs/bootstrap/archive/$BOOTSTRAP_VERSION.zip"
+
+# unpack the sources into the _sass/ directory
+echo "Unpacking sources..."
+unzip "$BOOTSTRAP_VERSION.zip" -d ./_sass
+
+# make a directory to put the Bootstrap 5 Sass sources into
+mkdir ./_sass/bootstrap
+
+# move the Sass sources to your new directory
+mv ./_sass/bootstrap-5.3.2/scss ./_sass/bootstrap/scss
+
+# delete all the other Bootstrap sources (i.e. except the Sass ones, which we moved)
+echo "Cleaning up..."
+rm -r ./_sass/bootstrap-5.3.2
+
+# delete the downloaded zip
+rm v5.3.2.zip
+
+echo "Done!"

--- a/local_setup.sh
+++ b/local_setup.sh
@@ -1,6 +1,0 @@
-wget "https://github.com/twbs/bootstrap/archive/v5.3.2.zip" # download the full Bootstrap 5 sources (including JS)
-unzip v5.3.2.zip -d ./_sass # unpack the sources into the _sass/ directory
-mkdir ./_sass/bootstrap # make a directory to put the Bootstrap 5 Sass sources into
-mv ./_sass/bootstrap-5.3.2/scss ./_sass/bootstrap/scss # move the sources to your new directory
-rm -r ./_sass/bootstrap-5.3.2 # delete all the other Bootstrap sources (i.e. except the Sass ones, which we moved)
-rm v5.3.2.zip # delete the downloaded zip


### PR DESCRIPTION
Update workflow to use jekyll instead of github-pages gem, fix docs link for places not using the kroxylicious domain.

We are currently using a GitHub Action that is pulling in the github-pages gem instead of the Jekyll one, so this PR fixes that by using the Jekyll-recommended workflow (rather than the GitHub-recommended one) which installs and sets everything up manually.

There was also a problem with using absolute_url for the docs link when rendering the site on any domain that wasn't kroxylicious.io, where it would append the path incorrectly (this was only a problem for `/docs` because it's not rendered by Jekyll). Using the relative_url filter for this link should fix this for people who want to test their changes under their own GitHub account, while still retaining functionality on the main site.