### PR TITLE
fix borken doc link

### DIFF
--- a/overview.markdown
+++ b/overview.markdown
@@ -5,7 +5,7 @@ permalink: /overview/
 toc: true
 ---
 
-This page provides an overview of how Kroxylicious works.  For more details, please refer to the [documentation](./kroxylicious).
+This page provides an overview of how Kroxylicious works.  For more details, please refer to the [documentation](https://kroxylicious.io/docs/v0.6.0/).
 
 #### What is Kroxylicious?
 


### PR DESCRIPTION
The "documentation" link is directing to an 404 page: https://kroxylicious.io/overview/kroxylicious . Fix it. 
Question: Do we have a label with the latest version number? Otherwise, we need to remember to update it when the new version released.