### PR TITLE
Add missing "old docs" warning messages to previous release docs pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   java
   x64-mingw32
   x86_64-darwin-22

--- a/docs/v0.5.1/index.adoc
+++ b/docs/v0.5.1/index.adoc
@@ -1,5 +1,6 @@
 ---
 title: Kroxylicious Proxy v0.5.1
+version_warning: <em>This documentation is for an older release of Kroxylicious, and may not reflect current functionality.</em>
 ---
 
 include::_files/index.adoc[leveloffset=0]

--- a/docs/v0.6.0/index.adoc
+++ b/docs/v0.6.0/index.adoc
@@ -1,5 +1,6 @@
 ---
 title: Kroxylicious Proxy v0.6.0
+version_warning: <em>This documentation is for an older release of Kroxylicious, and may not reflect current functionality.</em>
 ---
 
 include::_files/index.adoc[leveloffset=0]

--- a/docs/v0.7.0/index.adoc
+++ b/docs/v0.7.0/index.adoc
@@ -1,5 +1,6 @@
 ---
 title: Kroxylicious Proxy v0.7.0
+version_warning: <em>This documentation is for an older release of Kroxylicious, and may not reflect current functionality.</em>
 ---
 
 include::_files/index.adoc[leveloffset=0]


### PR DESCRIPTION
The docs pages for versions up to and including v0.5.0 have a message at the top which reads `This documentation is for an older release of Kroxylicious, and may not reflect current functionality.` This message is missing from the docs for v0.5.1, v0.6.0, and v0.7.0 (v0.8.0 is the current release so shouldn't have this message), so this PR is just to add that missing message to those pages.