### PR TITLE
Fix doc generation for v0.9.0

### DIFF
--- a/docs/v0.9.0/index.adoc
+++ b/docs/v0.9.0/index.adoc
@@ -1,4 +1,3 @@
-
 ---
 title: Kroxylicious Proxy v0.9.0
 ---


### PR DESCRIPTION
This extra newline is breaking the documentation rendering on the website for [0.9.0](https://kroxylicious.io/docs/v0.9.0/)
😱😱😱😱😱😱😱😱😱😱😱😱😱😱