### PR TITLE
Upgrade to actions/upload-pages-artifact@v3 in GitHub Actions

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -52,7 +52,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:


### PR DESCRIPTION
Upgrade actions/upload-pages-artifact from v2 to v3 to fix broken workflow [due to deprecation of actions/upload-artifact v3](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).

actions/upload-pages-artifact v3 uses  actions/upload-artifact v4.