### PR TITLE
Fix version number in 0.10.0 docs

### DIFF
--- a/docs/v0.10.0/_files/_assets/attributes.adoc
+++ b/docs/v0.10.0/_files/_assets/attributes.adoc
@@ -14,7 +14,7 @@
 :icons: font
 
 //Latest version
-:KroxyliciousVersion: 0.9
+:KroxyliciousVersion: 0.10
 :gitRef: releases/tag/v0.10.0
 :ApicurioVersion: 2.6.x
 


### PR DESCRIPTION
Fix `KroxyliciousVersion` in AsciiDoc properties for v0.10.0 docs.