### PR TITLE
DRAFT: Restructure docs navigation

### DIFF
--- a/_data/kroxylicious.yml
+++ b/_data/kroxylicious.yml
@@ -3,6 +3,9 @@ versions:
     url: '/kroxylicious'
   - title: 'v0.11.0'
     url: '/docs/v0.11.0/'
+    subsections:
+      - title: 'Proxy Guide'
+        url: '/docs/v0.11.0/kroxylicious-proxy/'
   - title: 'v0.10.0'
     url: '/docs/v0.10.0/'
   - title: 'v0.9.0'

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -47,11 +47,29 @@
             <a class="nav-link dropdown-toggle krx-nav-link py-2 px-0 px-lg-4" data-bs-toggle="dropdown" href="#" role="button" aria-expanded="false">Docs</a>
             <ul class="dropdown-menu">
               {% for version in site.data.kroxylicious.versions %}
+              {% if version.subsections %}
+              <li><hr class="dropdown-divider"></li>
+              <li><h6 class="dropdown-header">{{ version.title }}</h6></li>
+              {% endif %}
               <li>
                 <a class="dropdown-item {% if page.url == version.url %}active{% endif %} krx-nav-link py-2 px-0 px-lg-4" href="{{ version.url }}">
+                  {% if version.subsections %}
+                  Index
+                  {% else %}
                   {{ version.title }}
+                  {% endif %}
                 </a>
               </li>
+              {% if version.subsections %}
+              {% for subsection in version.subsections %}
+              <li>
+                <a class="dropdown-item {% if page.url == subsection.url %}active{% endif %} krx-nav-link py-2 px-0 px-lg-4" href="{{ subsection.url }}">
+                  {{ subsection.title }}
+                </a>
+              </li>
+              {% endfor %}
+              <li><hr class="dropdown-divider"></li>
+              {% endif %}
               {% endfor %}
             </ul>
           </li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.2/js/bootstrap.bundle.min.js" integrity="sha512-X/YkDZyjTf4wyc2Vy16YGCPHwAY8rZJY+POgokZjQB2mhIRFJCckEGc6YyX9eNsPfn0PzThEuNs+uaomE5CO6A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     {% seo %}
 </head>
-<body class="d-flex flex-column" data-bs-theme="light">
+<body class="d-flex flex-column min-vh-100" data-bs-theme="light">
 {% include nav.html %}
 <div class="container-fluid px-0 krx-content" data-bs-theme="light">
     {{ content }}

--- a/_sass/kroxylicious.scss
+++ b/_sass/kroxylicious.scss
@@ -42,6 +42,10 @@ a {
   color: $kroxy-dark-green;
 }
 
+.nav-item > .dropdown-menu {
+  min-width: 200px;
+}
+
 .krx-content * {
   scroll-margin-top: 5rem!important;
 }

--- a/docs/v0.10.0/index.adoc
+++ b/docs/v0.10.0/index.adoc
@@ -1,5 +1,6 @@
 ---
 title: Kroxylicious Proxy v0.10.0
+version_warning: <em>This documentation is for an older release of Kroxylicious, and may not reflect current functionality.</em>
 ---
 
 include::_files/index.adoc[leveloffset=0]

--- a/docs/v0.8.0/index.adoc
+++ b/docs/v0.8.0/index.adoc
@@ -1,5 +1,6 @@
 ---
 title: Kroxylicious Proxy v0.8.0
+version_warning: <em>This documentation is for an older release of Kroxylicious, and may not reflect current functionality.</em>
 ---
 
 include::_files/index.adoc[leveloffset=0]

--- a/docs/v0.9.0/index.adoc
+++ b/docs/v0.9.0/index.adoc
@@ -1,5 +1,6 @@
 ---
 title: Kroxylicious Proxy v0.9.0
+version_warning: <em>This documentation is for an older release of Kroxylicious, and may not reflect current functionality.</em>
 ---
 
 include::_files/index.adoc[leveloffset=0]


### PR DESCRIPTION
Fixes #106

Work in progress to add new docs subsections dynamically to dropdown nav (done), ~~and move old docs versions to an "older versions" index page and out of the main nav menu (in progress)~~ <- moving this to a second PR.

Trying to simplify things and avoid clutter.

Also includes some updating of "this is an older version" warnings on old docs versions I hadn't got around to adding it to. Probably we should find a better (i.e. not manual) way to do that in future but it's of very low importance.