### PR TITLE
Fix formatting of docs

### DIFF
--- a/_includes/asciidoctor-scripts/icons.html
+++ b/_includes/asciidoctor-scripts/icons.html
@@ -1,0 +1,77 @@
+<!-- The following script adds bootstrap classes to Asciidoc "admonitionblock" elements i.e. text blocks labelled info, warning, etc. -->
+<!-- Without this script they just appear as weirdly-formatted paragraphs, however it does add a little bit to page load time. -->
+<!-- There's some styles at the bottom of _sass/kroxylicious.scss to make this all work nicely and look good. -->
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        document.querySelectorAll(".admonitionblock.note").forEach((blockElem) => {
+            blockElem.classList.add("alert");
+            blockElem.setAttribute("role", "alert");
+            blockElem.classList.add("alert-info");
+            blockElem.querySelectorAll("i").forEach((iconElem) => {
+                var elemClassList = iconElem.classList;
+                // FontAwesome .fa -> Bootstrap Icons .bi
+                elemClassList.replace("fa", "bi");
+                // FontAwesome .icon-note -> Bootstrap Icons .bi-info-circle-fill
+                elemClassList.replace("icon-note", "bi-info-circle-fill");
+                // add layout and util classes
+                elemClassList.add("krx-docs-note", "ms-2", "me-4", "fs-5");
+            });
+        });
+        document.querySelectorAll(".admonitionblock.tip").forEach((blockElem) => {
+            blockElem.classList.add("alert");
+            blockElem.setAttribute("role", "alert");
+            blockElem.classList.add("alert-primary");
+            blockElem.querySelectorAll("i").forEach((iconElem) => {
+                var elemClassList = iconElem.classList;
+                // FontAwesome .fa -> Bootstrap Icons .bi
+                elemClassList.replace("fa", "bi");
+                // FontAwesome .icon-tip -> Bootstrap Icons .bi-lightbulb
+                elemClassList.replace("icon-tip", "bi-lightbulb");
+                // add layout and util classes
+                elemClassList.add("krx-docs-tip", "ms-2", "me-4", "fs-5");
+            });
+        })
+        document.querySelectorAll(".admonitionblock.warning").forEach((blockElem) => {
+            blockElem.classList.add("alert");
+            blockElem.setAttribute("role", "alert");
+            blockElem.classList.add("alert-warning");
+            blockElem.querySelectorAll("i").forEach((iconElem) => {
+                var elemClassList = iconElem.classList;
+                // FontAwesome .fa -> Bootstrap Icons .bi
+                elemClassList.replace("fa", "bi");
+                // FontAwesome .icon-warning -> Bootstrap Icons .bi-exclamation-triangle-fill
+                elemClassList.replace("icon-warning", "bi-exclamation-triangle-fill");
+                // add layout and util classes
+                elemClassList.add("krx-docs-warning", "ms-2", "me-4", "fs-5");
+            });
+        });
+        document.querySelectorAll(".admonitionblock.caution").forEach((blockElem) => {
+            blockElem.classList.add("alert");
+            blockElem.setAttribute("role", "alert");
+            blockElem.classList.add("alert-danger");
+            blockElem.querySelectorAll("i").forEach((iconElem) => {
+                var elemClassList = iconElem.classList;
+                // FontAwesome .fa -> Bootstrap Icons .bi
+                elemClassList.replace("fa", "bi");
+                // FontAwesome .icon-caution -> Bootstrap Icons .bi-dash-circle-fill
+                elemClassList.replace("icon-caution", "bi-dash-circle-fill");
+                // add layout and util classes
+                elemClassList.add("krx-docs-caution", "ms-2", "me-4", "fs-5");
+            });
+        });
+        document.querySelectorAll(".admonitionblock.important").forEach((blockElem) => {
+            blockElem.classList.add("alert");
+            blockElem.setAttribute("role", "alert");
+            blockElem.classList.add("alert-danger");
+            blockElem.querySelectorAll("i").forEach((iconElem) => {
+                var elemClassList = iconElem.classList;
+                // FontAwesome .fa -> Bootstrap Icons .bi
+                elemClassList.replace("fa", "bi");
+                // FontAwesome .icon-important -> Bootstrap Icons .bi-exclamation-circle-fill
+                elemClassList.replace("icon-important", "bi-exclamation-circle-fill");
+                // add layout and util classes
+                elemClassList.add("krx-docs-important", "ms-2", "me-4", "fs-5");
+            });
+        });
+    });
+</script>

--- a/_includes/asciidoctor-scripts/sectanchors.html
+++ b/_includes/asciidoctor-scripts/sectanchors.html
@@ -1,0 +1,13 @@
+<!-- The following script fixes an accessibility issue with the sectanchors injected by AsciiDoc not containing any content. -->
+<!-- The script adds a span which the anchor CSS applies to, then moves the header text inside the anchor element. -->
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll("a.anchor").forEach((anchorElem) => {
+      var anchorSpan = document.createElement('span');
+      anchorSpan.setAttribute("class", "anchor-icon");
+      anchorElem.appendChild(anchorSpan);
+      anchorElem.appendChild(anchorElem.nextSibling);
+      anchorElem.setAttribute("class", anchorElem.getAttribute("class") + " text-decoration-none text-reset")
+    })
+  })
+</script>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -33,16 +33,5 @@ layout: default
     </div>
   </div>
 </div>
-<!-- The following script fixes an accessibility issue with the sectanchors injected by AsciiDoc not containing any content. -->
-<!-- The script adds a span which the anchor CSS applies to, then moves the header text inside the anchor element. -->
-<script>
-  document.addEventListener("DOMContentLoaded", function () {
-    document.querySelectorAll("a.anchor").forEach((anchorElem) => {
-      var anchorSpan = document.createElement('span');
-      anchorSpan.setAttribute("class", "anchor-icon");
-      anchorElem.appendChild(anchorSpan);
-      anchorElem.appendChild(anchorElem.nextSibling);
-      anchorElem.setAttribute("class", anchorElem.getAttribute("class") + " text-decoration-none text-reset")
-    })
-  })
-</script>
+{% include asciidoctor-scripts/icons.html %}
+{% include asciidoctor-scripts/sectanchors.html %}

--- a/_sass/kroxylicious.scss
+++ b/_sass/kroxylicious.scss
@@ -42,6 +42,12 @@ a {
   color: $kroxy-dark-green;
 }
 
+// Override default Bootstrap icon sizing and positioning for alerts
+.alert .bi {
+  font-size: xx-large!important;
+  vertical-align: middle!important;
+}
+
 .nav-item > .dropdown-menu {
   min-width: 200px;
 }
@@ -161,7 +167,7 @@ div.highlighter-rouge {
   }
 }
 
-// Anchor Links
+// [DOCS] Anchor Links
 
 h2>a.anchor>span, h3>a.anchor>span, h4>a.anchor>span, h5>a.anchor>span, h6>a.anchor>span {
   font-family: bootstrap-icons!important;
@@ -188,4 +194,85 @@ h2:hover>a.anchor>span, h3:hover>a.anchor>span, h4:hover>a.anchor>span, h5:hover
 
 h2:hover>a.anchor>span:hover, h3:hover>a.anchor>span:hover, h4:hover>a.anchor>span:hover, h5:hover>a.anchor>span:hover, h6:hover>a.anchor>span:hover {
   color: rgba($secondary, 1);
+}
+
+// [DOCS] Asciidoc formatting fixes
+
+.admonitionblock {
+  width: 100%;
+  margin: 10px 0 20px 0;
+}
+
+.admonitionblock > table {
+  width: 100%;
+  height: 100%;
+}
+
+.admonitionblock > table td {
+  padding-left: 1.125em;
+  padding-right: 1.25em;
+  height: 100%;
+  align-content: center;
+}
+
+.admonitionblock > table td.icon {
+  text-align: center;
+  width: 5em!important;
+}
+
+.admonitionblock > table td.icon .title {
+  font-weight: bold;
+  font-family: $font-family-sans-serif;
+  text-transform: uppercase
+}
+
+.admonitionblock i.bi {
+  margin: auto!important;
+  padding: 0 5px;
+}
+
+.colist > table td {
+  align-content: start;
+  -webkit-align-content: flex-start;
+}
+
+.conum[data-value] {
+  display: inline-block;
+  color: $white !important;
+  background: $gray-800;
+  border-radius: 50%;
+  margin-right: 10px;
+  text-align: center;
+  font-size: .75em;
+  width: 1.67em;
+  height: 1.67em;
+  line-height: 1.67em;
+  font-family: $font-family-sans-serif;
+  font-style: normal;
+  font-weight: bold
+}
+
+.conum[data-value] * {
+  color: #fff !important
+}
+
+.conum[data-value]+b {
+  display: none
+}
+
+.conum[data-value]::after {
+  content: attr(data-value)
+}
+
+pre .conum[data-value] {
+  position: relative;
+  top: -.125em
+}
+
+b.conum * {
+  color: inherit !important
+}
+
+.conum:not([data-value]):empty {
+  display: none
 }


### PR DESCRIPTION
## Summary:

- Adds a script in `_includes/asciidoctor-scripts/icons.html` to change some HTML classes on the release docs pages
- Adds some CSS to `_sass/kroxylicious.scss` to fix some missing styles on the release docs pages
- Moves the script to fix sectanchors out of the docs layout file and into `_includes/asciidoctor-scripts/sectanchors.html` to keep things neat

## Longer description:

### Problem:

The release docs are currently not formatted correctly on the website. Compare the development docs:

<img width="1708" alt="Screenshot 2025-03-27 at 13 27 21" src="https://github.com/user-attachments/assets/558add5e-1280-4937-bf20-b18fb222f544" />

With the latest release docs:

<img width="1487" alt="Screenshot 2025-03-27 at 13 27 04" src="https://github.com/user-attachments/assets/396fc0c1-f617-4a84-aeae-bcd22e01b01f" />

This is because the default Asciidoctor stylesheet is missing from the docs pages, as it's trying to use the ones Jekyll provides for the rest of the site. However the styles used by the rest of the site were not written with the Asciidoctor stylesheet in mind, so they do not apply completely and some things are missing.

### Other Issues:

To complicate matters further, [Asciidoctor](https://docs.asciidoctor.org/asciidoc/latest/macros/icons-font/) uses [FontAwesome](https://fontawesome.com/) (an SIL OFL licensed project with a free and paid tier) while the website uses [Bootstrap Icons](https://icons.getbootstrap.com/) (MIT licensed OSS, completely free), and this default icon library used by Asciidoctor cannot be changed (you can use text instead of icons but it looks weird so I elected not to do that). These two icon libraries also aren't 1:1 in terms of what icons they have (or allow you to use, in the case of FontAwesome's free tier) and they also use completely different element class names to apply icon images and styles.

### Fix:

To fix this without adding yet another font library (and associated licenses and such) to the site, I've added a script to the docs layout (via an `_includes`) which transforms these classes from the FontAwesome ones applied by Asciidoctor to my best approximation of an equivalent class in Bootstrap Icons. The script also applies some other Bootstrap Sass classes (to turn these [Asciidoc admonitions](https://docs.asciidoctor.org/asciidoc/latest/blocks/admonitions/) into [Bootstrap alerts](https://getbootstrap.com/docs/5.3/components/alerts/)) and a few classes specific to the styling of our site (all the stuff prefixed with `krx-`).

I've then recreated and tweaked the relevant missing parts of the default Asciidoctor stylesheet we're using on the development docs, but inside the website's `_sass/kroxylicious.scss` main stylesheet so they should be accessible all over the site (just in case any Asciidoc content ever makes its way outside `/docs`).