### PR TITLE
DRAFT: Docs Restructure Part 2

### DIFF
--- a/_data/kroxylicious.yml
+++ b/_data/kroxylicious.yml
@@ -1,6 +1,7 @@
 versions:
   - title: 'Development'
     url: '/kroxylicious'
+    development: true
   - title: 'v0.11.0'
     url: '/docs/v0.11.0/'
     subsections:
@@ -10,6 +11,10 @@ versions:
     url: '/docs/v0.10.0/'
   - title: 'v0.9.0'
     url: '/docs/v0.9.0/'
+  - title: 'Archive'
+    url: '/docs/archive/'
+    archive: true
+older_versions:
   - title: 'v0.8.0'
     url: '/docs/v0.8.0/'
   - title: 'v0.7.0'

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -47,9 +47,17 @@
             <a class="nav-link dropdown-toggle krx-nav-link py-2 px-0 px-lg-4" data-bs-toggle="dropdown" href="#" role="button" aria-expanded="false">Docs</a>
             <ul class="dropdown-menu">
               {% for version in site.data.kroxylicious.versions %}
-              {% if version.subsections %}
+              {% if version.subsections or version.archive %}
               <li><hr class="dropdown-divider"></li>
-              <li><h6 class="dropdown-header">{{ version.title }}</h6></li>
+              <li>
+                <h6 class="dropdown-header">
+                  {% if version.subsections %}
+                  {{ version.title }}
+                  {% else %}
+                  For all older versions:
+                  {% endif %}
+                </h6>
+              </li>
               {% endif %}
               <li>
                 <a class="dropdown-item {% if page.url == version.url %}active{% endif %} krx-nav-link py-2 px-0 px-lg-4" href="{{ version.url }}">
@@ -68,7 +76,9 @@
                 </a>
               </li>
               {% endfor %}
+              {% unless version.archive %}
               <li><hr class="dropdown-divider"></li>
+              {% endunless %}
               {% endif %}
               {% endfor %}
             </ul>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -10,8 +10,15 @@ layout: default
             {{ page.title }}
           </h1>
         <div class="card-text g-0">
+          {% if page.is_archive %}
+          {% capture blurb %}
+          {% include_relative blurb.markdown %}
+          {% endcapture %}
+          {{ blurb | markdownify }}
+          {% else %}
           <p><em>This documentation is for a stable release version of Kroxylicious. For the documentation from the latest development version of Kroxylicious, <a href="{{ '/kroxylicious' | relative_url }}">click here</a>.</small></em></p>
           {{ page.document | tocify_asciidoc }}
+          {% endif %}
         </div>
       </div>
     </div>
@@ -23,7 +30,7 @@ layout: default
           <div class="col-auto">
             <div class="card-text ms-3 m-2">
               {% if page.version_warning %}
-              {% include bs-alert.html type="warning" content=page.version_warning %}
+              {% include bs-alert.html type="warning" icon="exclamation-triangle-fill" content=page.version_warning %}
               {% endif %}
               {{ content }}
             </div>

--- a/docs/archive/blurb.markdown
+++ b/docs/archive/blurb.markdown
@@ -1,0 +1,8 @@
+{% assign latest_release_version = site.data.kroxylicious.versions | where: "development", nil | first %}
+{% assign last_unarchived_version = site.data.kroxylicious.versions | where: "archive", nil | last %}
+
+Documentation for all versions of Kroxylicious prior to {{ last_unarchived_version.title }} can be found here.
+
+The documentation linked here is for older releases of Kroxylicious, and may not reflect current functionality.
+
+The Kroxylicious project recommends using the latest stable release to ensure you stay up-to-date with the latest features and bugfixes. The latest release version of Kroxylicious is {{ latest_release_version.title }}, you can find the documentation for this latest stable release [here]({{ latest_release_version.url | absolute_url }}).

--- a/docs/archive/index.markdown
+++ b/docs/archive/index.markdown
@@ -1,0 +1,29 @@
+---
+layout: docs
+title: Kroxylicious Documentation Archive
+permalink: /docs/archive/
+is_archive: true
+---
+{% assign earliest_documented_version = site.data.kroxylicious.older_versions | last %}
+{% capture earliest_docs_info %}
+Please note this is the earliest Kroxylicious release documentation available on our website. Documentation sources for all versions, including those prior to {{ earliest_documented_version.title }}, are available from the Kroxylicious GitHub repository under their respective [release tags](https://github.com/kroxylicious/kroxylicious/releases).
+{% endcapture %}
+
+## Archived Release Documentation
+
+{% for version in site.data.kroxylicious.older_versions %}
+### Kroxylicious Proxy {{ version.title }}
+{% if version.title == earliest_documented_version.title %}
+{% include bs-alert.html type="info" icon="info-circle-fill" content=earliest_docs_info %}
+{% endif %}
+{% if version.subsections %}
+{% for subsection in version.subsections %}
+- [{{ subsection.title }}]({{ subsection.url }})
+{% endfor %}
+{% else %}
+- [Documentation]({{ version.url }})
+{% endif %}
+{% if version.javadoc %}
+- [Javadoc]({{ version.javadoc }})
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
Move old docs versions to an "older versions" archive page and out of the main nav dropdown menu.

New docs nav dropdown looks like this:
![image](https://github.com/user-attachments/assets/5be6b761-2720-4d14-96bc-b14cdfe97fbd)

Archive page looks like this:
![image](https://github.com/user-attachments/assets/30b17356-7c8c-4028-8972-c8e1fd99d885)

There's room in the archive page functionality to handle docs with subsections (like the v0.11.0 docs) and the addition of javadoc links if we elect to do that at some stage.

Currently in draft because I'll need to modify the release docs publishing pipeline to work with the changes to the site data structure before we merge.