### PR TITLE
v0.12.0 docs: Remove links to operator and developer's guide for now

### DIFF
--- a/_data/kroxylicious.yml
+++ b/_data/kroxylicious.yml
@@ -3,6 +3,9 @@ versions:
     url: '/kroxylicious'
   - title: 'v0.12.0'
     url: '/docs/v0.12.0/'
+    subsections:
+      - title: 'Proxy Guide'
+        url: '/docs/v0.12.0/kroxylicious-proxy/'
   - title: 'v0.11.0'
     url: '/docs/v0.11.0/'
     subsections:

--- a/docs/v0.12.0/_files/index.adoc
+++ b/docs/v0.12.0/_files/index.adoc
@@ -4,6 +4,6 @@ This release of Kroxylicious is documented in the following guides:
 
 link:kroxylicious-proxy/[Proxy guide]:: Covers using the proxy, including configuration, security and operation.
 
-link:kroxylicious-operator/[Operator for Kubernetes]:: Covers using the Kubernetes operator for the proxy, including configuration, security and operation.
+// link:kroxylicious-operator/[Operator for Kubernetes]:: Covers using the Kubernetes operator for the proxy, including configuration, security and operation.
 
-link:developers-guide/[Developer's guide]:: Covers writing plugins for the proxy in the Java programming language
+// link:developers-guide/[Developer's guide]:: Covers writing plugins for the proxy in the Java programming language


### PR DESCRIPTION
Fixes some broken links.  I expect this manual chore will disappear once we start publishing the other docs.