### PR TITLE
Manually fix image locations with v0.13.0 docs

### DIFF
--- a/docs/v0.13.0/_files/assemblies/assembly-operator-api.adoc
+++ b/docs/v0.13.0/_files/assemblies/assembly-operator-api.adoc
@@ -25,7 +25,7 @@ Specifies filter mechanisms for use with a virtual cluster.
 `KafkaService` and `KafkaProtocolFilter` resources may reference a `ConfigMap` to provide non-sensitive configuration such as trusted CA certificates.
 
 .Example input resources, and the references between them.
-image::../_assets/operator-input-resource-topology.svg["Diagram showing the input resources, KafkaProxy, VirtualKafkaCluster, etc, as boxes, connected by arrows representing the references between the resources."]
+image::operator-input-resource-topology.svg["Diagram showing the input resources, KafkaProxy, VirtualKafkaCluster, etc, as boxes, connected by arrows representing the references between the resources."]
 
 Based on the input resources just described, the operator generates the core Kubernetes resources needed to deploy the Kroxylicious proxy, such as:
 
@@ -39,6 +39,6 @@ You can make use of Kubernete's Role-Based Access Control (RBAC) to divide respo
 For example, you might grant networking engineers the ability to configure `KafkaProxy` and `KafkaProxyIngress`, while giving application developers the ability to configure `VirtualKafkaCluster`, `KafkaService`, and `KafkaProtocolFilter` resources.
 
 .The generated Kubernetes resources, and the relationships between them
-image::../_assets/operator-output-resource-topology.svg["Diagram showing the output resources, Deployment, Pod, ConfigMap, Service, with arrows showing the Deployment managing the Pod, the Pod mounting the ConfigMap, and the Service selecting the Pod."]
+image::operator-output-resource-topology.svg["Diagram showing the output resources, Deployment, Pod, ConfigMap, Service, with arrows showing the Deployment managing the Pod, the Pod mounting the ConfigMap, and the Service selecting the Pod."]
 
 include::../modules/con-api-compatability-operator.adoc[leveloffset=+1]

--- a/docs/v0.13.0/_files/modules/monitoring/con-prometheus-metrics-proxy.adoc
+++ b/docs/v0.13.0/_files/modules/monitoring/con-prometheus-metrics-proxy.adoc
@@ -87,7 +87,7 @@ This is apparent through the metrics.
 * If a filter changes the size of the message, the downstream size metrics will be different to the upstream size metrics.
 
 .Downstream and upstream message metrics in the proxy
-image::../_assets/monitoring-message-counters.svg["Conceptual diagram showing the downstream and upstream message metrics within the proxy, illustrating how they respond to message transit through it."]
+image::monitoring-message-counters.svg["Conceptual diagram showing the downstream and upstream message metrics within the proxy, illustrating how they respond to message transit through it."]
 
 Message metrics include the following labels: `virtual_cluster` (the virtual cluster's name), `node_id` (the broker's node ID), `api_key` (the message type), `api_version`, and `decoded` (a flag indicating if the message was decoded by the proxy).
 


### PR DESCRIPTION
I'm not sure of the correct permanent fix, but I can see that the prefixing we do of image locations in the source asciidoc is messing up the publication on the website.

This is a temporary workaround.  We need to fix it properly.