### PR TITLE
Build the website using the same Dockerfile in the github action

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -25,29 +25,41 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    services:
+      # we spin up a registry to share the image built by build-push-action with the later docker run step
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.4.4' # Not needed with a .ruby-version file
-          cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         uses: actions/configure-pages@v3
-      - name: Install rake
-        run: gem install rake
-      - name: Update Bundler and Setup Jekyll
-        run: bundle install && bundle update --bundler
-      - name: Setup Go
-        uses: actions/setup-go@v5
-      - name: Setup ASCIIToSVG
-        run: go install github.com/asciitosvg/asciitosvg/cmd/a2s@latest
-      - name: Download Bootstrap 5 SCSS Sources
-        run: ./bootstrap_setup.sh
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          # this is required for the subsequent build to be able to push to the registry on localhost:5000
+          driver-opts: network=host
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: localhost:5000/kroxy-jekyll:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: |
+          docker run \
+            --rm \
+            -u "$(id -u):$(id -g)" \
+            -v "$(pwd):/site" \
+            localhost:5000/kroxy-jekyll:latest \
+            bash -c 'eval "$(rbenv init -)" && cp -r /css/_sass/bootstrap /site/_sass/ && bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"'
         env:
           JEKYLL_ENV: production
       - name: Upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ _site
 .jekyll-metadata
 vendor
 .idea
+*.iml
 */bootstrap/

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,14 @@ ENV RBENV_ROOT /usr/local/rbenv
 RUN git clone https://github.com/rbenv/rbenv.git ${RBENV_ROOT} && \
     git clone https://github.com/rbenv/ruby-build.git ${RBENV_ROOT}/plugins/ruby-build
 
-ENV PATH="${RBENV_ROOT}/bin:/root/go/bin:${PATH}"
+ENV PATH="${RBENV_ROOT}/bin:${PATH}"
 RUN eval "$(rbenv init -)" && \
     rbenv install 3.4.4 && \
     rbenv global 3.4.4 && \
     gem install bundler && \
-    go install github.com/asciitosvg/asciitosvg/cmd/a2s@latest
+    go install github.com/asciitosvg/asciitosvg/cmd/a2s@latest && \
+    mv /root/go/bin/a2s /usr/local/bin/ && \
+    chmod 777 /usr/local/bin/a2s
 
 COPY Gemfile .
 COPY Gemfile.lock .
@@ -41,7 +43,6 @@ RUN ./bootstrap_setup.sh
 
 RUN mkdir /site/
 WORKDIR /site/
-
 EXPOSE 4000
 # Note --incremental mode is ineffective on the Mac owing to https://github.com/containers/podman/issues/22343.  Use force_regenerate.sh to trigger the incremental reload after changing the file on the host.
 CMD eval "$(rbenv init -)" && cp -r /css/_sass/bootstrap /site/_sass/ && bundle exec jekyll serve --host ${JEKYLL_SERVE_BIND} --incremental --disable-disk-cache --destination /tmp/site


### PR DESCRIPTION
This brings the local development and github actions builds closer together. Using the same Dockerfile in both places to build the static content.

1. we build the image and cache the layers it to gha, this means the build step should usually be very fast.
2. we do not copy in all the sources into the image because we mount the sources in locally and in the workflow. this makes the image very cacheable.
3. moves a2s into /usr/local/bin so that the github user id can access it (previously it was under /root).