### PR TITLE
Fix guide layout to show version warning correctly

### DIFF
--- a/_layouts/guide.html
+++ b/_layouts/guide.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 <!-- _layouts/guide.html -->
-{%- if page.release != site.data.release.latest -%}
+{%- if page.version != site.data.kroxylicious.latestRelease -%}
 <div class="admonitionblock note alert alert-info mb-0" role="alert">
     <i class="bi bi-info-circle-fill krx-docs-note ms-2 me-4 fs-5" title="Note"></i>
     This documentation covers a non-current version of Kroxylicious. The latest version is {{ site.data.kroxylicious.latestRelease }}.


### PR DESCRIPTION
This wouldn't be visible until we have guides for past versions

(test by updating _data/kroxylicious.yml latestRelease)