### PR TITLE
Sort releases

### DIFF
--- a/_data/release/0_10_0.yaml
+++ b/_data/release/0_10_0.yaml
@@ -1,3 +1,5 @@
+version: 0.10.0
+rank: 0000.0010.0000
 assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
 assets:
   - name: Proxy

--- a/_data/release/0_11_0.yaml
+++ b/_data/release/0_11_0.yaml
@@ -1,3 +1,5 @@
+version: 0.11.0
+rank: 0000.0011.0000
 assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
 assets:
   - name: Proxy

--- a/_data/release/0_12_0.yaml
+++ b/_data/release/0_12_0.yaml
@@ -1,3 +1,5 @@
+version: 0.12.0
+rank: 0000.0012.0000
 releaseNotesUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)/
 assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/download/v$(VERSION)/
 assets:

--- a/_data/release/0_13_0.yaml
+++ b/_data/release/0_13_0.yaml
@@ -1,3 +1,5 @@
+version: 0.13.0
+rank: 0000.0013.0000
 releaseNotesUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)/
 assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/download/v$(VERSION)/
 assets:

--- a/_data/release/0_1_0.yaml
+++ b/_data/release/0_1_0.yaml
@@ -1,3 +1,5 @@
+version: 0.1.0
+rank: 0000.0001.0000
 assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
 assets:
   - name: Proxy

--- a/_data/release/0_2_0.yaml
+++ b/_data/release/0_2_0.yaml
@@ -1,3 +1,5 @@
+version: 0.2.0
+rank: 0000.0002.0000
 assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
 assets:
   - name: Proxy

--- a/_data/release/0_3_0.yaml
+++ b/_data/release/0_3_0.yaml
@@ -1,3 +1,5 @@
+version: 0.3.0
+rank: 0000.0003.0000
 assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
 assets:
   - name: Proxy

--- a/_data/release/0_4_0.yaml
+++ b/_data/release/0_4_0.yaml
@@ -1,3 +1,5 @@
+version: 0.4.0
+rank: 0000.0004.0000
 assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
 assets:
   - name: Proxy

--- a/_data/release/0_4_1.yaml
+++ b/_data/release/0_4_1.yaml
@@ -1,3 +1,5 @@
+version: 0.5.0
+rank: 0000.0005.0000
 assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
 assets:
   - name: Proxy

--- a/_data/release/0_5_0.yaml
+++ b/_data/release/0_5_0.yaml
@@ -1,3 +1,5 @@
+version: 0.5.0
+rank: 0000.0005.0000
 assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
 assets:
   - name: Proxy

--- a/_data/release/0_5_1.yaml
+++ b/_data/release/0_5_1.yaml
@@ -1,3 +1,5 @@
+version: 0.5.1
+rank: 0000.0005.0001
 assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
 assets:
   - name: Proxy

--- a/_data/release/0_6_0.yaml
+++ b/_data/release/0_6_0.yaml
@@ -1,3 +1,5 @@
+version: 0.6.0
+rank: 0000.0006.0000
 assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
 assets:
   - name: Proxy

--- a/_data/release/0_7_0.yaml
+++ b/_data/release/0_7_0.yaml
@@ -1,3 +1,5 @@
+version: 0.7.0
+rank: 0000.0007.0000
 assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
 assets:
   - name: Proxy

--- a/_data/release/0_8_0.yaml
+++ b/_data/release/0_8_0.yaml
@@ -1,3 +1,5 @@
+version: 0.8.0
+rank: 0000.0008.0000
 assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
 assets:
   - name: Proxy

--- a/_data/release/0_9_0.yaml
+++ b/_data/release/0_9_0.yaml
@@ -1,3 +1,5 @@
+version: 0.9.0
+rank: 0000.0009.0000
 assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
 assets:
   - name: Proxy

--- a/_layouts/download-release.html
+++ b/_layouts/download-release.html
@@ -7,6 +7,8 @@ layout: default
 {%- else -%}
 {%- assign version = page.url | split: "/" | slice: -1 | first -%}
 {%- endif -%}
+{%- assign underscored_version = version | replace: '.', '_' -%}
+{%- assign release = site.data.release[underscored_version] -%}
 
 <div class="row align-items-start justify-content-center my-5">
   <div class="col-lg-3 mb-5" role="complementary" aria-labelledby="page-title">
@@ -36,14 +38,10 @@ layout: default
   </div>
   <div class="col-lg-6" role="main">
       <div class="row row-cols-1 row-cols-md-2 g-4">
-{%- for rel in site.data.release -%}
-{%- assign release = rel[1] -%}
-{%- assign releaseVersion = rel[0] | replace: '_', '.' -%}
-{%- if releaseVersion == version -%}
           <div class="col">
               <div class="card shadow mb-2 h-100 mx-2">
                   <div class="card-header">
-                      <h2 class="card-title fs-4"><a href='{{ release.releaseNotesUrl | replace: "$(VERSION)", releaseVersion }}'>Release notes</a></h2>
+                      <h2 class="card-title fs-4"><a href='{{ release.releaseNotesUrl | replace: "$(VERSION)", version }}'>Release notes</a></h2>
                   </div>
                   <div class="card-body mx-3 my-2">
                       What's been added, deprecated and/or removed.
@@ -53,7 +51,7 @@ layout: default
           <div class="col">
               <div class="card shadow mb-2 h-100 mx-2">
                   <div class="card-header">
-                      <h2 class="card-title fs-4"><a href="/documentation/{{ releaseVersion }}/">Documentation and quick starts</a></h2>
+                      <h2 class="card-title fs-4"><a href="/documentation/{{ version }}/">Documentation and quick starts</a></h2>
                   </div>
                   <div class="card-body mx-3 my-2">
                       Learn how to use what you're downloading.
@@ -69,7 +67,7 @@ layout: default
                   <div class="card-body mx-3 my-2">
                       {{ asset.description }}<br/>
 {%- for dl in asset.downloads -%}
-                      <a href='{{ release.assetBaseUrl | replace: "$(VERSION)", releaseVersion }}{{ dl.path | replace: "$(VERSION)", releaseVersion }}'>{{ dl.format }}</a>{% unless forloop.last %} | {% endunless -%}
+                      <a href='{{ release.assetBaseUrl | replace: "$(VERSION)", version }}{{ dl.path | replace: "$(VERSION)", version }}'>{{ dl.format }}</a>{% unless forloop.last %} | {% endunless -%}
 {%- endfor -%}
                   </div>
               </div>
@@ -86,8 +84,8 @@ layout: default
                       {{ image.name }} container images are published to <a href="{{ image.url }}">this repository</a>.
                       Pull them to your container runtime using one of the following commands:
                       <ul>
-                          <li><code>docker pull {{ image.registry }}:{{ image.tag  | replace: "$(VERSION)", releaseVersion }}</code></li>
-                          <li><code>podman pull {{ image.registry }}:{{ image.tag  | replace: "$(VERSION)", releaseVersion }}</code></li>
+                          <li><code>docker pull {{ image.registry }}:{{ image.tag  | replace: "$(VERSION)", version }}</code></li>
+                          <li><code>podman pull {{ image.registry }}:{{ image.tag  | replace: "$(VERSION)", version }}</code></li>
 {%- if image.digest -%}
                           <li><code>docker pull {{ image.registry }}@{{ image.digest }}</code></li>
                           <li><code>podman pull {{ image.registry }}@{{ image.digest }}</code></li>
@@ -98,8 +96,6 @@ layout: default
           </div>
 {%- endfor -%}
 {%- endif -%}
-{%- endif -%}
-{%- endfor -%}
       </div>
   </div>
 </div>

--- a/release-archives/index.md
+++ b/release-archives/index.md
@@ -2,38 +2,11 @@
 layout: default
 title: Release Archives
 ---
-{%- comment -%}
-`site.data.release` an object and unordered.
-Liquid lacks any ability to sort it, or convert it to an array for sorting. 
-This following monstrosity is to work around that.
-{%- endcomment -%}
-{%- assign versionsList="" -%}
-{%- for major in (0..999) -%}
-  {%- assign probe1=major | append: "_1_0" -%}
-  {%- if site.data.release[probe1] -%}
-    {%- for minor in (1..999) -%}
-      {%- assign probe2=major | append: "_" | append: minor | append: "_0" -%}
-      {%- if site.data.release[probe2] -%}
-        {%- for micro in (0..999) -%}
-          {%- assign key=major | append: "_" | append: minor | append: "_" | append: micro -%}
-          {%- if site.data.release[key] -%}
-            {%- assign versionsList=versionsList | append: "," | append: key -%}
-          {%- else -%}
-            {%- break -%}
-          {%- endif -%}
-        {%- endfor -%}
-      {%- else -%}
-        {%- break -%}
-      {%- endif -%}
-    {%- endfor -%}
-  {%- else -%}
-    {%- break -%}
-  {%- endif -%}
-{%- endfor -%}
-{%- assign versionsList=versionsList | remove_first: "," | split: "," | reverse -%}
-{%- comment -%}
-endmonstrosity
-{%- endcomment -%}
+{% assign releases = "" | split: "" %}
+{% for release in site.data.release %}
+{% assign releases = releases | push: release[1] %}
+{% endfor %}
+{% assign releases = releases | sort: "rank" | reverse %}
 
 <div class="row align-items-start justify-content-center my-5">
   <div class="col-lg-3 mb-5" role="complementary" aria-labelledby="page-title">
@@ -41,8 +14,8 @@ endmonstrosity
       <div class="card-body">
       <h1 id="page-title" class="fs-3">{{ page.title }}</h1>
       <ul>
-{%- for relKey in versionsList -%}
-{%- assign releaseVersion=relKey | replace: '_', '.' -%}
+{%- for release in releases -%}
+{%- assign releaseVersion=release.version -%}
 <li><a href="#{{ releaseVersion }}">{{ releaseVersion }}</a></li>
 {%- endfor -%}
       </ul>
@@ -50,9 +23,8 @@ endmonstrosity
     </div>
   </div>
   <div class="col-lg-6" role="main">
-{%- for relKey in versionsList -%}
-{%- assign releaseVersion=relKey | replace: '_', '.' -%}
-{%- assign release=site.data.release | map: relKey -%}
+{%- for release in releases -%}
+{%- assign releaseVersion=release.version -%}
     <div class="card shadow mb-4">
       <div class="card-body mx-3 my-2">
 <h2 id="{{ releaseVersion }}" class="card-title fs-4">{{ releaseVersion }}


### PR DESCRIPTION
This requires each release file to contain a rank property which orders by the release version. We need to leftpad the version components with zeroes to keep the ordering lexicographical.

It also adds a `version` property to the release YAML since I couldn't find a way to sort an array of arrays. And working backwards from `rank` would be painful.

This removes the monstrosity