### PR TITLE
Rework the quickstarts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -67,8 +67,6 @@ include:
 collections:
   use_cases:
     output: false
-  quickstarts:
-    output: false
 
 keep_files:
   - images

--- a/_data/documentation/0_10_0.yaml
+++ b/_data/documentation/0_10_0.yaml
@@ -1,10 +1,21 @@
 docs:
-  - title: Quick start
-    description: Start here if you're just getting started with Kroxylicious.
-    path: /quickstarts
+  - title: Proxy quickstart
+    description: Start here if you're experimenting with the proxy for the first time.
+    tags:
+      - proxy
+    path: /docs/quickstart/deploy/
+    rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
+    rank: '010'
+  - title: Developer quickstart
+    description: Start here if you're developing a filter for the first time.
+    tags:
+      - developer
+    path: /docs/quickstart/develop/
+    rank: '031'
   - title: Javadoc
     description: The Java API documentation.
     path: https://javadoc.io/doc/io.kroxylicious/kroxylicious-api/$(VERSION)/index.html
+    rank: '033'

--- a/_data/documentation/0_10_0.yaml
+++ b/_data/documentation/0_10_0.yaml
@@ -1,5 +1,5 @@
 docs:
-  - title: Proxy quickstart
+  - title: Proxy quick start
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
@@ -9,7 +9,7 @@ docs:
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
     rank: '010'
-  - title: Developer quickstart
+  - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer

--- a/_data/documentation/0_11_0.yaml
+++ b/_data/documentation/0_11_0.yaml
@@ -1,7 +1,16 @@
 docs:
-  - title: Quick start
-    description: Start here if you're just getting started with Kroxylicious.
-    path: /quickstarts
+  - title: Proxy quickstart
+    description: Start here if you're experimenting with the proxy for the first time.
+    tags:
+      - proxy
+    path: /docs/quickstart/deploy/
+    rank: '000'
+  - title: Developer quickstart
+    description: Start here if you're developing a filter for the first time.
+    tags:
+      - developer
+    path: /docs/quickstart/develop/
+    rank: '031'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/kroxylicious-proxy/
@@ -11,6 +20,8 @@ docs:
   - title: Developer Guide
     description: Describes how to write Kroxylicious plugins using the Java programming language.
     path: html/developer/
+    rank: '032'
   - title: Javadoc
     description: The Java API documentation.
     path: https://javadoc.io/doc/io.kroxylicious/kroxylicious-api/$(VERSION)/index.html
+    rank: '033'

--- a/_data/documentation/0_11_0.yaml
+++ b/_data/documentation/0_11_0.yaml
@@ -1,11 +1,11 @@
 docs:
-  - title: Proxy quickstart
+  - title: Proxy quick start
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
     path: /docs/quickstart/deploy/
     rank: '000'
-  - title: Developer quickstart
+  - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer

--- a/_data/documentation/0_12_0.yaml
+++ b/_data/documentation/0_12_0.yaml
@@ -1,5 +1,5 @@
 docs:
-  - title: Proxy quickstart
+  - title: Proxy quick start
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
@@ -9,7 +9,7 @@ docs:
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/kroxylicious-proxy/
     rank: '010'
-  - title: Developer quickstart
+  - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer

--- a/_data/documentation/0_12_0.yaml
+++ b/_data/documentation/0_12_0.yaml
@@ -1,14 +1,22 @@
 docs:
-  - title: Proxy quick start
+  - title: Proxy quickstart
     description: Start here if you're experimenting with the proxy for the first time.
-    path: /quickstarts
-  - title: Developer quick start
-    description: Start here if you're developing a filter for the first time.
-    path: /quickstarts
+    tags:
+      - proxy
+    path: /docs/quickstart/deploy/
+    rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/kroxylicious-proxy/
+    rank: '010'
+  - title: Developer quickstart
+    description: Start here if you're developing a filter for the first time.
+    tags:
+      - developer
+    path: /docs/quickstart/develop/
+    rank: '031'
   - title: Javadoc
     description: The Java API documentation.
     path: https://javadoc.io/doc/io.kroxylicious/kroxylicious-api/$(VERSION)/index.html
+    rank: '033'
     

--- a/_data/documentation/0_13_0.yaml
+++ b/_data/documentation/0_13_0.yaml
@@ -1,5 +1,5 @@
 docs:
-  - title: Proxy quickstart
+  - title: Proxy quick start
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
@@ -25,7 +25,7 @@ docs:
       - kubernetes
     rank: '020'
     path: html/kroxylicious-operator
-  - title: Developer quickstart
+  - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer

--- a/_data/documentation/0_13_0.yaml
+++ b/_data/documentation/0_13_0.yaml
@@ -3,7 +3,7 @@ docs:
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
-    path: /quickstarts
+    path: /docs/quickstart/deploy/
     rank: '000'
   - title: Proxy guide
     description: "Covers using the proxy, including configuration, security and operation."
@@ -29,7 +29,7 @@ docs:
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer
-    path: /quickstarts
+    path: /docs/quickstart/develop/
     rank: '031'
   - title: Kroxylicious Developer guide
     description: Covers writing plugins for the proxy in the Java programming language

--- a/_data/documentation/0_14_0-SNAPSHOT.yaml
+++ b/_data/documentation/0_14_0-SNAPSHOT.yaml
@@ -1,5 +1,5 @@
 docs:
-  - title: Proxy quickstart
+  - title: Proxy quick start
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
@@ -25,7 +25,7 @@ docs:
       - kubernetes
     rank: '020'
     path: html/kroxylicious-operator
-  - title: Developer quickstart
+  - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer

--- a/_data/documentation/0_1_0.yaml
+++ b/_data/documentation/0_1_0.yaml
@@ -1,10 +1,21 @@
 docs:
-  - title: Quick start
-    description: Start here if you're just getting started with Kroxylicious.
-    path: /quickstarts
+  - title: Proxy quickstart
+    description: Start here if you're experimenting with the proxy for the first time.
+    tags:
+      - proxy
+    path: /docs/quickstart/deploy/
+    rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
+    rank: '010'
+  - title: Developer quickstart
+    description: Start here if you're developing a filter for the first time.
+    tags:
+      - developer
+    path: /docs/quickstart/develop/
+    rank: '031'
   - title: Javadoc
     description: The Java API documentation.
     path: https://javadoc.io/doc/io.kroxylicious/kroxylicious-api/$(VERSION)/index.html
+    rank: '033'

--- a/_data/documentation/0_1_0.yaml
+++ b/_data/documentation/0_1_0.yaml
@@ -1,5 +1,5 @@
 docs:
-  - title: Proxy quickstart
+  - title: Proxy quick start
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
@@ -9,7 +9,7 @@ docs:
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
     rank: '010'
-  - title: Developer quickstart
+  - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer

--- a/_data/documentation/0_2_0.yaml
+++ b/_data/documentation/0_2_0.yaml
@@ -1,10 +1,21 @@
 docs:
-  - title: Quick start
-    description: Start here if you're just getting started with Kroxylicious.
-    path: /quickstarts
+  - title: Proxy quickstart
+    description: Start here if you're experimenting with the proxy for the first time.
+    tags:
+      - proxy
+    path: /docs/quickstart/deploy/
+    rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
+    rank: '010'
+  - title: Developer quickstart
+    description: Start here if you're developing a filter for the first time.
+    tags:
+      - developer
+    path: /docs/quickstart/develop/
+    rank: '031'
   - title: Javadoc
     description: The Java API documentation.
     path: https://javadoc.io/doc/io.kroxylicious/kroxylicious-api/$(VERSION)/index.html
+    rank: '033'

--- a/_data/documentation/0_2_0.yaml
+++ b/_data/documentation/0_2_0.yaml
@@ -1,5 +1,5 @@
 docs:
-  - title: Proxy quickstart
+  - title: Proxy quick start
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
@@ -9,7 +9,7 @@ docs:
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
     rank: '010'
-  - title: Developer quickstart
+  - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer

--- a/_data/documentation/0_3_0.yaml
+++ b/_data/documentation/0_3_0.yaml
@@ -1,10 +1,21 @@
 docs:
-  - title: Quick start
-    description: Start here if you're just getting started with Kroxylicious.
-    path: /quickstarts
+  - title: Proxy quickstart
+    description: Start here if you're experimenting with the proxy for the first time.
+    tags:
+      - proxy
+    path: /docs/quickstart/deploy/
+    rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
+    rank: '010'
+  - title: Developer quickstart
+    description: Start here if you're developing a filter for the first time.
+    tags:
+      - developer
+    path: /docs/quickstart/develop/
+    rank: '031'
   - title: Javadoc
     description: The Java API documentation.
     path: https://javadoc.io/doc/io.kroxylicious/kroxylicious-api/$(VERSION)/index.html
+    rank: '033'

--- a/_data/documentation/0_3_0.yaml
+++ b/_data/documentation/0_3_0.yaml
@@ -1,5 +1,5 @@
 docs:
-  - title: Proxy quickstart
+  - title: Proxy quick start
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
@@ -9,7 +9,7 @@ docs:
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
     rank: '010'
-  - title: Developer quickstart
+  - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer

--- a/_data/documentation/0_4_0.yaml
+++ b/_data/documentation/0_4_0.yaml
@@ -1,10 +1,21 @@
 docs:
-  - title: Quick start
-    description: Start here if you're just getting started with Kroxylicious.
-    path: /quickstarts
+  - title: Proxy quickstart
+    description: Start here if you're experimenting with the proxy for the first time.
+    tags:
+      - proxy
+    path: /docs/quickstart/deploy/
+    rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
+    rank: '010'
+  - title: Developer quickstart
+    description: Start here if you're developing a filter for the first time.
+    tags:
+      - developer
+    path: /docs/quickstart/develop/
+    rank: '031'
   - title: Javadoc
     description: The Java API documentation.
     path: https://javadoc.io/doc/io.kroxylicious/kroxylicious-api/$(VERSION)/index.html
+    rank: '033'

--- a/_data/documentation/0_4_0.yaml
+++ b/_data/documentation/0_4_0.yaml
@@ -1,5 +1,5 @@
 docs:
-  - title: Proxy quickstart
+  - title: Proxy quick start
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
@@ -9,7 +9,7 @@ docs:
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
     rank: '010'
-  - title: Developer quickstart
+  - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer

--- a/_data/documentation/0_4_1.yaml
+++ b/_data/documentation/0_4_1.yaml
@@ -1,10 +1,21 @@
 docs:
-  - title: Quick start
-    description: Start here if you're just getting started with Kroxylicious.
-    path: /quickstarts
+  - title: Proxy quickstart
+    description: Start here if you're experimenting with the proxy for the first time.
+    tags:
+      - proxy
+    path: /docs/quickstart/deploy/
+    rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
+    rank: '010'
+  - title: Developer quickstart
+    description: Start here if you're developing a filter for the first time.
+    tags:
+      - developer
+    path: /docs/quickstart/develop/
+    rank: '031'
   - title: Javadoc
     description: The Java API documentation.
     path: https://javadoc.io/doc/io.kroxylicious/kroxylicious-api/$(VERSION)/index.html
+    rank: '033'

--- a/_data/documentation/0_4_1.yaml
+++ b/_data/documentation/0_4_1.yaml
@@ -1,5 +1,5 @@
 docs:
-  - title: Proxy quickstart
+  - title: Proxy quick start
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
@@ -9,7 +9,7 @@ docs:
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
     rank: '010'
-  - title: Developer quickstart
+  - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer

--- a/_data/documentation/0_5_0.yaml
+++ b/_data/documentation/0_5_0.yaml
@@ -1,10 +1,21 @@
 docs:
-  - title: Quick start
-    description: Start here if you're just getting started with Kroxylicious.
-    path: /quickstarts
+  - title: Proxy quickstart
+    description: Start here if you're experimenting with the proxy for the first time.
+    tags:
+      - proxy
+    path: /docs/quickstart/deploy/
+    rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
+    rank: '010'
+  - title: Developer quickstart
+    description: Start here if you're developing a filter for the first time.
+    tags:
+      - developer
+    path: /docs/quickstart/develop/
+    rank: '031'
   - title: Javadoc
     description: The Java API documentation.
     path: https://javadoc.io/doc/io.kroxylicious/kroxylicious-api/$(VERSION)/index.html
+    rank: '033'

--- a/_data/documentation/0_5_0.yaml
+++ b/_data/documentation/0_5_0.yaml
@@ -1,5 +1,5 @@
 docs:
-  - title: Proxy quickstart
+  - title: Proxy quick start
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
@@ -9,7 +9,7 @@ docs:
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
     rank: '010'
-  - title: Developer quickstart
+  - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer

--- a/_data/documentation/0_5_1.yaml
+++ b/_data/documentation/0_5_1.yaml
@@ -1,10 +1,21 @@
 docs:
-  - title: Quick start
-    description: Start here if you're just getting started with Kroxylicious.
-    path: /quickstarts
+  - title: Proxy quickstart
+    description: Start here if you're experimenting with the proxy for the first time.
+    tags:
+      - proxy
+    path: /docs/quickstart/deploy/
+    rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
+    rank: '010'
+  - title: Developer quickstart
+    description: Start here if you're developing a filter for the first time.
+    tags:
+      - developer
+    path: /docs/quickstart/develop/
+    rank: '031'
   - title: Javadoc
     description: The Java API documentation.
     path: https://javadoc.io/doc/io.kroxylicious/kroxylicious-api/$(VERSION)/index.html
+    rank: '033'

--- a/_data/documentation/0_5_1.yaml
+++ b/_data/documentation/0_5_1.yaml
@@ -1,5 +1,5 @@
 docs:
-  - title: Proxy quickstart
+  - title: Proxy quick start
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
@@ -9,7 +9,7 @@ docs:
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
     rank: '010'
-  - title: Developer quickstart
+  - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer

--- a/_data/documentation/0_6_0.yaml
+++ b/_data/documentation/0_6_0.yaml
@@ -1,10 +1,21 @@
 docs:
-  - title: Quick start
-    description: Start here if you're just getting started with Kroxylicious.
-    path: /quickstarts
+  - title: Proxy quickstart
+    description: Start here if you're experimenting with the proxy for the first time.
+    tags:
+      - proxy
+    path: /docs/quickstart/deploy/
+    rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
+    rank: '010'
+  - title: Developer quickstart
+    description: Start here if you're developing a filter for the first time.
+    tags:
+      - developer
+    path: /docs/quickstart/develop/
+    rank: '031'
   - title: Javadoc
     description: The Java API documentation.
     path: https://javadoc.io/doc/io.kroxylicious/kroxylicious-api/$(VERSION)/index.html
+    rank: '033'

--- a/_data/documentation/0_6_0.yaml
+++ b/_data/documentation/0_6_0.yaml
@@ -1,5 +1,5 @@
 docs:
-  - title: Proxy quickstart
+  - title: Proxy quick start
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
@@ -9,7 +9,7 @@ docs:
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
     rank: '010'
-  - title: Developer quickstart
+  - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer

--- a/_data/documentation/0_7_0.yaml
+++ b/_data/documentation/0_7_0.yaml
@@ -1,10 +1,21 @@
 docs:
-  - title: Quick start
-    description: Start here if you're just getting started with Kroxylicious.
-    path: /quickstarts
+  - title: Proxy quickstart
+    description: Start here if you're experimenting with the proxy for the first time.
+    tags:
+      - proxy
+    path: /docs/quickstart/deploy/
+    rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
+    rank: '010'
+  - title: Developer quickstart
+    description: Start here if you're developing a filter for the first time.
+    tags:
+      - developer
+    path: /docs/quickstart/develop/
+    rank: '031'
   - title: Javadoc
     description: The Java API documentation.
     path: https://javadoc.io/doc/io.kroxylicious/kroxylicious-api/$(VERSION)/index.html
+    rank: '033'

--- a/_data/documentation/0_7_0.yaml
+++ b/_data/documentation/0_7_0.yaml
@@ -1,5 +1,5 @@
 docs:
-  - title: Proxy quickstart
+  - title: Proxy quick start
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
@@ -9,7 +9,7 @@ docs:
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
     rank: '010'
-  - title: Developer quickstart
+  - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer

--- a/_data/documentation/0_8_0.yaml
+++ b/_data/documentation/0_8_0.yaml
@@ -1,10 +1,21 @@
 docs:
-  - title: Quick start
-    description: Start here if you're just getting started with Kroxylicious.
-    path: /quickstarts
+  - title: Proxy quickstart
+    description: Start here if you're experimenting with the proxy for the first time.
+    tags:
+      - proxy
+    path: /docs/quickstart/deploy/
+    rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
+    rank: '010'
+  - title: Developer quickstart
+    description: Start here if you're developing a filter for the first time.
+    tags:
+      - developer
+    path: /docs/quickstart/develop/
+    rank: '031'
   - title: Javadoc
     description: The Java API documentation.
     path: https://javadoc.io/doc/io.kroxylicious/kroxylicious-api/$(VERSION)/index.html
+    rank: '033'

--- a/_data/documentation/0_8_0.yaml
+++ b/_data/documentation/0_8_0.yaml
@@ -1,5 +1,5 @@
 docs:
-  - title: Proxy quickstart
+  - title: Proxy quick start
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
@@ -9,7 +9,7 @@ docs:
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
     rank: '010'
-  - title: Developer quickstart
+  - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer

--- a/_data/documentation/0_9_0.yaml
+++ b/_data/documentation/0_9_0.yaml
@@ -1,12 +1,21 @@
 docs:
-  - title: Quick start
-    description: Start here if you're just getting started with Kroxylicious.
-    path: /quickstarts
-    rank: "010"
+  - title: Proxy quickstart
+    description: Start here if you're experimenting with the proxy for the first time.
+    tags:
+      - proxy
+    path: /docs/quickstart/deploy/
+    rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
-    rank: "020"
+    rank: '010'
+  - title: Developer quickstart
+    description: Start here if you're developing a filter for the first time.
+    tags:
+      - developer
+    path: /docs/quickstart/develop/
+    rank: '031'
   - title: Javadoc
     description: The Java API documentation.
     path: https://javadoc.io/doc/io.kroxylicious/kroxylicious-api/$(VERSION)/index.html
+    rank: '033'

--- a/_data/documentation/0_9_0.yaml
+++ b/_data/documentation/0_9_0.yaml
@@ -1,5 +1,5 @@
 docs:
-  - title: Proxy quickstart
+  - title: Proxy quick start
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
@@ -9,7 +9,7 @@ docs:
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/
     rank: '010'
-  - title: Developer quickstart
+  - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -47,13 +47,13 @@
                         </a>
                     </li>
                     <li class="mb-2">
-                        <a class="text-body link-underline-dark link-underline-opacity-0 link-underline-opacity-10-hover" href="{{ '/quickstarts/' | absolute_url }}">
-                            Get Started
+                        <a class="text-body link-underline-dark link-underline-opacity-0 link-underline-opacity-10-hover" href="{{ '/download/' | absolute_url }}">
+                            Download
                         </a>
                     </li>
                     <li class="mb-2">
-                        <a class="text-body link-underline-dark link-underline-opacity-0 link-underline-opacity-10-hover" href="{{ '/kroxylicious' | absolute_url }}">
-                            Docs
+                        <a class="text-body link-underline-dark link-underline-opacity-0 link-underline-opacity-10-hover" href="{{ '/documentation/' | absolute_url }}">
+                            Documentation
                         </a>
                     </li>
                     <li class="mb-2">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,3 +1,5 @@
+{% assign path_components = page.url | remove_first: "/" | split: "/" %}
+
 <header class="navbar navbar-expand-lg navbar-dark krx-navbar sticky-top">
   <nav class="container-xxl krx-gutter flex-wrap flex-lg-nowrap" data-bs-theme="dark" aria-label="Main navigation">
     <div class="d-lg-none" style="width: 2.25rem;"></div>
@@ -20,7 +22,7 @@
         <hr class="d-lg-none text-white-50">
         <ul class="navbar-nav flex-row flex-wrap ms-md-auto">
           <li class="nav-item col-6 col-lg-auto">
-            <a class="nav-link {% if page.url == '/overview/' %}active{% endif %} krx-nav-link py-2 px-0 px-lg-4" href="{{ '/overview/' | absolute_url }}">
+            <a class="nav-link {% if path_components[0] == 'overview' %}active{% endif %} krx-nav-link py-2 px-0 px-lg-4" href="{{ '/overview/' | absolute_url }}">
               Overview
             </a>
           </li>
@@ -28,7 +30,7 @@
             <div class="vr d-none d-lg-flex h-100 text-white"></div>
           </li>
           <li class="nav-item col-6 col-lg-auto">
-            <a class="nav-link {% if page.url == '/use-cases/' %}active{% endif %} krx-nav-link py-2 px-0 px-lg-4" href="{{ '/download/' | absolute_url }}">
+            <a class="nav-link {% if path_components[0] == 'download' %}active{% endif %} krx-nav-link py-2 px-0 px-lg-4" href="{{ '/download/' | absolute_url }}">
               Download
             </a>
           </li>
@@ -36,7 +38,7 @@
             <div class="vr d-none d-lg-flex h-100 text-white"></div>
           </li>
           <li class="nav-item col-6 col-lg-auto">
-            <a class="nav-link {% if page.url == '/quickstarts/' %}active{% endif %} krx-nav-link py-2 px-0 px-lg-4" href="{{ '/documentation/' | absolute_url }}">
+            <a class="nav-link {% if path_components[0] == 'documentation' %}active{% endif %} krx-nav-link py-2 px-0 px-lg-4" href="{{ '/documentation/' | absolute_url }}">
               Documentation
             </a>
           </li>
@@ -44,7 +46,7 @@
             <div class="vr d-none d-lg-flex h-100 text-white"></div>
           </li>
           <li class="nav-item col-6 col-lg-auto">
-            <a class="nav-link {% if page.url == '/blog/' %}active{% endif %} krx-nav-link py-2 px-0 px-lg-4" href="{{ '/blog/' | absolute_url }}">
+            <a class="nav-link {% if path_components[0] == 'blog' %}active{% endif %} krx-nav-link py-2 px-0 px-lg-4" href="{{ '/blog/' | absolute_url }}">
               Blog
             </a>
           </li>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -38,7 +38,7 @@
             <div class="vr d-none d-lg-flex h-100 text-white"></div>
           </li>
           <li class="nav-item col-6 col-lg-auto">
-            <a class="nav-link {% if path_components[0] == 'documentation' %}active{% endif %} krx-nav-link py-2 px-0 px-lg-4" href="{{ '/documentation/' | absolute_url }}">
+            <a class="nav-link {% if path_components[0] == 'documentation' or path_components[0] == 'docs' %}active{% endif %} krx-nav-link py-2 px-0 px-lg-4" href="{{ '/documentation/' | absolute_url }}">
               Documentation
             </a>
           </li>

--- a/_layouts/quickstart.html
+++ b/_layouts/quickstart.html
@@ -1,11 +1,14 @@
 ---
 layout: default
 ---
-<div class="card gx-5 gy-5 m-lg-5">
-    <div class="card-header">
-        <div class="card-title display-6 mx-2 mt-3 mb-4"><i class="bi bi-stopwatch me-4"></i>{{ page.title }}</div>
-    </div>
-    <div class="card-body tab-content p-4 p-lg-5" idrole="main">
-        {{ content }}
+
+<div class="row justify-content-center">
+    <div class="col-11 col-lg-8 card shadow gx-5 gy-5 m-lg-5">
+        <div class="card-header">
+            <div class="card-title display-6 mx-2 mt-3 mb-4"><i class="bi bi-stopwatch me-4"></i>{{ page.title }}</div>
+        </div>
+        <div class="card-body tab-content p-4 p-lg-5" idrole="main">
+            {{ content }}
+        </div>
     </div>
 </div>

--- a/_layouts/quickstart.html
+++ b/_layouts/quickstart.html
@@ -1,34 +1,10 @@
 ---
 layout: default
 ---
-<div class="card gx-5 gy-5 m-lg-5" role="navigation" aria-label="Quickstart navigation">
+
     <div class="card-header">
-        <div class="card-title display-6 mx-2 mt-3 mb-4"><i class="bi bi-stopwatch me-4"></i>Quick Start Guide</div>
-        <ul class="nav nav-tabs nav-justified fs-5 card-header-tabs" id="quickstart" role="tablist">
-            {% for quickstart in site.quickstarts %}
-                {% if quickstart.htmlid and quickstart.tab_title %}
-                    <li class="nav-item">
-                        <button class="nav-link krx-card-nav-link {% if forloop.first %}active{% endif %}"
-                                id="{{ quickstart.htmlid }}" data-bs-toggle="tab"
-                                data-bs-target="#{{ quickstart.htmlid }}-tab-pane" type="button"
-                                role="tab" aria-controls="{{ quickstart.htmlid }}-tab-pane"
-                                aria-selected="{% if forloop.first %}true{% else %}false{% endif %}">
-                            {{ quickstart.tab_title }}
-                        </button>
-                    </li>
-                {% endif %}
-            {% endfor %}
-        </ul>
+        <div class="card-title display-6 mx-2 mt-3 mb-4"><i class="bi bi-stopwatch me-4"></i>{{ page.title }}</div>
     </div>
-    <div class="card-body tab-content p-4 p-lg-5" id="quickstartContent" role="main" aria-labelledby="{{ quickstart.htmlid }}">
-        {% for quickstart in site.quickstarts %}
-            {% if quickstart.htmlid and quickstart.tab_title %}
-                <div class="tab-pane fade show {% if forloop.first %}active{% endif %}"
-                     id="{{ quickstart.htmlid }}-tab-pane" role="tabpanel"
-                     aria-labelledby="{{ quickstart.htmlid }}" tabindex="{{ forloop.index0 }}">
-                    {{ quickstart.content | markdownify }}
-                </div>
-            {% endif %}
-        {% endfor %}
+    <div class="card-body tab-content p-4 p-lg-5" idrole="main">
+        {{ content }}
     </div>
-</div>

--- a/_layouts/quickstart.html
+++ b/_layouts/quickstart.html
@@ -1,14 +1,19 @@
 ---
 layout: default
 ---
-
 <div class="row justify-content-center">
     <div class="col-11 col-lg-8 card shadow gx-5 gy-5 m-lg-5">
-        <div class="card-header">
-            <div class="card-title display-6 mx-2 mt-3 mb-4"><i class="bi bi-stopwatch me-4"></i>{{ page.title }}</div>
-        </div>
-        <div class="card-body tab-content p-4 p-lg-5" idrole="main">
-            {{ content }}
+        <div class="card-body mx-2" role="main" aria-labelledby="page-title">
+            <div class="card-title display-6 mt-3 mb-4">
+                <h1 id="page-title"><i class="bi bi-stopwatch me-4"></i>{{ page.title }}</h1>
+            </div>
+            <div class="row g-0">
+                <div class="col-auto">
+                    <div class="card-text">
+                        {{ content }}
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/_layouts/quickstart.html
+++ b/_layouts/quickstart.html
@@ -1,10 +1,11 @@
 ---
 layout: default
 ---
-
+<div class="card gx-5 gy-5 m-lg-5">
     <div class="card-header">
         <div class="card-title display-6 mx-2 mt-3 mb-4"><i class="bi bi-stopwatch me-4"></i>{{ page.title }}</div>
     </div>
     <div class="card-body tab-content p-4 p-lg-5" idrole="main">
         {{ content }}
     </div>
+</div>

--- a/_sass/kroxylicious.scss
+++ b/_sass/kroxylicious.scss
@@ -161,8 +161,9 @@ a {
 // ensure padding for code blocks
 .highlight {
   text-wrap: wrap;
-  padding: 1.5em;
+  padding: 0.5em;
   border-radius: 4px;
+  margin-bottom: 0;
 }
 
 div.highlighter-rouge {

--- a/docs/quickstart/deploy/index.markdown
+++ b/docs/quickstart/deploy/index.markdown
@@ -1,9 +1,11 @@
 ---
 layout: quickstart
-title: Deployment quickstart
+title: Proxy quick start
 ---
+
+This quick start will guide you through deploying the proxy.
+
 Kroxylicious is a Java application based on [Netty](https://netty.io/), which means it will run anywhere you can run a JVM. (That's a lot of places!)
-To help you get started with Kroxylicious, we've created this quick setup guide.
 
 # Getting started
 

--- a/docs/quickstart/deploy/index.markdown
+++ b/docs/quickstart/deploy/index.markdown
@@ -31,7 +31,7 @@ If you get an error or the command doesn't return anything, you may not have a J
 
 You will also need a running Apache Kafka® cluster for Kroxylicious to proxy. The official Apache Kafka® [quick start](https://kafka.apache.org/documentation/#quickstart) has instructions for setting up a local bare metal cluster.
 
-Once your cluster is set up, the cluster bootstrap address used by Kroxylicious can be changed in the configuration YAML file (see the [**Configure**](#configure-deployment) section below).
+Once your cluster is set up, the cluster bootstrap address used by Kroxylicious can be changed in the configuration YAML file (see the [**Configure**](#step-2-configure-the-proxy) section below).
 
 ## Step 1: Download and install the proxy
 
@@ -56,7 +56,7 @@ An example configuration file can be found in the `config/` directory of the ext
 
 For this quickstart we will use Kroxylicious in Port-Per-Broker configuration, and assume that both your Apache Kafka® cluster and clients are running on your local machine and using their default configuration. This means we can use the example proxy config file that comes with Kroxylicious.
 
-If your machine uses a non-standard port configuration, or if you have used custom settings for your Apache Kafka® cluster (or if your cluster is running on a different machine) you will need to adjust your Kroxylicious configuration accordingly. More information about configuring Kroxylicious can be found in the [documentation](https://kroxylicious.io/kroxylicious/#_deploying_proxies).
+If your machine uses a non-standard port configuration, or if you have used custom settings for your Apache Kafka® cluster (or if your cluster is running on a different machine) you will need to adjust your Kroxylicious configuration accordingly. More information about configuring Kroxylicious can be found in the [documentation](/documentation/).
 
 ## Step 3: Start the proxy
 
@@ -83,19 +83,19 @@ Your client(s) will need to point to the proxy (using the configured address) ra
 {% capture apacheClientContent %}
 In each command below, substitute `$KROXYLICIOUS_BOOTSTRAP` for the bootstrap address of your proxy instance.
 
-## 1. Create a topic via the proxy
+### i. Create a topic via the proxy
 Create a topic called "my_topic" using the `kafka-topics.sh` command line client:
 ```shell
 bin/kafka-topics.sh --create --topic my_topic --bootstrap-server $KROXYLICIOUS_BOOTSTRAP
 ```
 
-## 2. Produce a string to your topic via the proxy
+### ii. Produce a string to your topic via the proxy
 Produce the string "hello world" to your new topic using the `kafka-console-producer.sh` command line client:
 ```shell
 echo "hello world" | bin/kafka-console-producer.sh --topic my_topic --bootstrap-server $KROXYLICIOUS_BOOTSTRAP
 ```
 
-## 3. Consume your string from your topic via the proxy
+### iii. Consume your string from your topic via the proxy
 Consume your string ("hello world") from your topic ("my_topic") using the `kafka-console-consumer.sh` command line client:
 ```shell
 bin/kafka-console-consumer.sh --topic my_topic --from-beginning --bootstrap-server $KROXYLICIOUS_BOOTSTRAP
@@ -105,19 +105,19 @@ bin/kafka-console-consumer.sh --topic my_topic --from-beginning --bootstrap-serv
 {% capture kafClientContent %}
 In each command below, substitute `$KROXYLICIOUS_BOOTSTRAP` for the bootstrap address of your proxy instance.
 
-## 1. Create a topic with Kaf via the proxy
+### i. Create a topic with Kaf via the proxy
 Create a topic called "my_topic" using Kaf:
 ```shell
 kaf -b $KROXYLICIOUS_BOOTSTRAP topic create my_topic
 ```
 
-## 2. Produce a string to your topic with Kaf via the proxy
+### ii. Produce a string to your topic with Kaf via the proxy
 Produce the string "hello world" to your new topic:
 ```shell
 echo "hello world" | kaf -b $KROXYLICIOUS_BOOTSTRAP produce my_topic
 ```
 
-## 3. Consume your string from your topic with Kaf via the proxy
+### iii. Consume your string from your topic with Kaf via the proxy
 Consume your string ("hello world") from your topic ("my_topic"):
 ```shell
 kaf -b $KROXYLICIOUS_BOOTSTRAP consume my_topic

--- a/docs/quickstart/deploy/index.markdown
+++ b/docs/quickstart/deploy/index.markdown
@@ -29,38 +29,36 @@ If you get an error or the command doesn't return anything, you may not have a J
 
 ### Apache Kafka®
 
-You will also need a running Apache Kafka® cluster for Kroxylicious to proxy. The official Apache Kafka® [quickstart](https://kafka.apache.org/documentation/#quickstart) has instructions for setting up a local bare metal cluster.
+You will also need a running Apache Kafka® cluster for Kroxylicious to proxy. The official Apache Kafka® [quick start](https://kafka.apache.org/documentation/#quickstart) has instructions for setting up a local bare metal cluster.
 
 Once your cluster is set up, the cluster bootstrap address used by Kroxylicious can be changed in the configuration YAML file (see the [**Configure**](#configure-deployment) section below).
 
-## Downloading Kroxylicious
+## Step 1: Download and install the proxy
 
 Kroxylicious can be downloaded from the [releases](https://github.com/kroxylicious/kroxylicious/releases) page of the Kroxylicious GitHub repository, or from Maven Central.
 
 In GitHub, all releases since v0.4.0 have an attached `kroxylicious-app-*-bin.zip` file. Download the latest version of this zip, and optionally verify the contents of the package with the attached `kroxylicious-app-*-bin.zip.asc` file.
 
 {% capture os_archive_note %}
-If you're trying Kroxylicious out on Linux or macOS, you may find the `.tar.gz` format easier to work with. We're using the `.zip` files in this quickstart for cross-platform compatibility, but we recommend you use whichever format you're most familiar with.
+If you're trying Kroxylicious out on Linux or macOS, you may find the `.tar.gz` format easier to work with. We're using the `.zip` files in this quick start for cross-platform compatibility, but we recommend you use whichever format you're most familiar with.
 {% endcapture %}
 
 {% include bs-alert.html type="primary" icon="info-circle-fill" content=os_archive_note %}
 
-# Install
-
 Extract the downloaded Kroxylicious Zip file into the directory you would like to install Kroxylicious in.
 Ensure the `kroxylicious-start.sh` and `run-java.sh` files in the `bin/` directory within the extracted folder have at least read and execute (`r-x`) permissions for the owner.
 
-# Configure
+## Step 2: Configure the proxy
 
-Kroxylicious is configured with YAML. From the configuration file you can specify how Kroxylicious presents each Apache Kafka&#174; broker to clients, where Kroxylicious will locate the Apache Kafka&#174; cluster(s) to be proxied, and which filters Kroxylicious should use along with any configuration for those filters.
+Kroxylicious is configured with YAML. From the configuration file you can specify how Kroxylicious presents each Apache Kafka® broker to clients, where Kroxylicious will locate the Apache Kafka® cluster(s) to be proxied, and which filters Kroxylicious should use along with any configuration for those filters.
 
 An example configuration file can be found in the `config/` directory of the extracted Kroxylicious folder, which you can either modify or use as reference for creating your own configuration file.
 
-For this quickstart we will use Kroxylicious in Port-Per-Broker configuration, and assume that both your Apache Kafka&#174; cluster and clients are running on your local machine and using their default configuration. This means we can use the example proxy config file that comes with Kroxylicious.
+For this quickstart we will use Kroxylicious in Port-Per-Broker configuration, and assume that both your Apache Kafka® cluster and clients are running on your local machine and using their default configuration. This means we can use the example proxy config file that comes with Kroxylicious.
 
-If your machine uses a non-standard port configuration, or if you have used custom settings for your Apache Kafka&#174; cluster (or if your cluster is running on a different machine) you will need to adjust your Kroxylicious configuration accordingly. More information about configuring Kroxylicious can be found in the [documentation](https://kroxylicious.io/kroxylicious/#_deploying_proxies).
+If your machine uses a non-standard port configuration, or if you have used custom settings for your Apache Kafka® cluster (or if your cluster is running on a different machine) you will need to adjust your Kroxylicious configuration accordingly. More information about configuring Kroxylicious can be found in the [documentation](https://kroxylicious.io/kroxylicious/#_deploying_proxies).
 
-# Run
+## Step 3: Start the proxy
 
 From within the extracted Kroxylicious folder, run the following command:
 
@@ -70,9 +68,9 @@ From within the extracted Kroxylicious folder, run the following command:
 
 To use your own configuration file instead of the example, just replace the file path after `--config`.
 
-# Use
+## Step 4: Configure Kafka clients to use it
 
-To use your Kroxylicious proxy, your client(s) will need to point to the proxy (using the configured address) rather than directly at the Apache Kafka&#174; cluster.
+Your client(s) will need to point to the proxy (using the configured address) rather than directly at the Apache Kafka® cluster.
 
 [//]: # (====================================================================)
 [//]: # (START - Use Section Examples Tabbed Card)
@@ -83,21 +81,21 @@ To use your Kroxylicious proxy, your client(s) will need to point to the proxy (
 {% capture use_examples_htmlid %}{{ page.htmlid }}-useExamples{% endcapture %}
 
 {% capture apacheClientContent %}
-In each command below, substitute `$KROXYLICIOUS_BOOTSTRAP` for the bootstrap address of your Kroxylicious instance.
+In each command below, substitute `$KROXYLICIOUS_BOOTSTRAP` for the bootstrap address of your proxy instance.
 
-## 1. Create a topic via Kroxylicious
+## 1. Create a topic via the proxy
 Create a topic called "my_topic" using the `kafka-topics.sh` command line client:
 ```shell
 bin/kafka-topics.sh --create --topic my_topic --bootstrap-server $KROXYLICIOUS_BOOTSTRAP
 ```
 
-## 2. Produce a string to your topic via Kroxylicious
+## 2. Produce a string to your topic via the proxy
 Produce the string "hello world" to your new topic using the `kafka-console-producer.sh` command line client:
 ```shell
 echo "hello world" | bin/kafka-console-producer.sh --topic my_topic --bootstrap-server $KROXYLICIOUS_BOOTSTRAP
 ```
 
-## 3. Consume your string from your topic via Kroxylicious
+## 3. Consume your string from your topic via the proxy
 Consume your string ("hello world") from your topic ("my_topic") using the `kafka-console-consumer.sh` command line client:
 ```shell
 bin/kafka-console-consumer.sh --topic my_topic --from-beginning --bootstrap-server $KROXYLICIOUS_BOOTSTRAP
@@ -105,21 +103,21 @@ bin/kafka-console-consumer.sh --topic my_topic --from-beginning --bootstrap-serv
 {% endcapture %}
 
 {% capture kafClientContent %}
-In each command below, substitute `$KROXYLICIOUS_BOOTSTRAP` for the bootstrap address of your Kroxylicious instance.
+In each command below, substitute `$KROXYLICIOUS_BOOTSTRAP` for the bootstrap address of your proxy instance.
 
-## 1. Create a topic with Kaf via Kroxylicious
+## 1. Create a topic with Kaf via the proxy
 Create a topic called "my_topic" using Kaf:
 ```shell
 kaf -b $KROXYLICIOUS_BOOTSTRAP topic create my_topic
 ```
 
-## 2. Produce a string to your topic with Kaf via Kroxylicious
+## 2. Produce a string to your topic with Kaf via the proxy
 Produce the string "hello world" to your new topic:
 ```shell
 echo "hello world" | kaf -b $KROXYLICIOUS_BOOTSTRAP produce my_topic
 ```
 
-## 3. Consume your string from your topic with Kaf via Kroxylicious
+## 3. Consume your string from your topic with Kaf via the proxy
 Consume your string ("hello world") from your topic ("my_topic"):
 ```shell
 kaf -b $KROXYLICIOUS_BOOTSTRAP consume my_topic
@@ -132,7 +130,7 @@ kaf -b $KROXYLICIOUS_BOOTSTRAP consume my_topic
 {% capture kaf_htmlid %}{{use_examples_htmlid}}-kafClient{% endcapture %}
 
 {% capture use_example_tabs %}
-{% include nested-card-tabbed/tab.html htmlid=apache_htmlid is_active_tab=true tab_title="Using Kroxylicious with the Apache Kafka&#174; command line clients" %}
+{% include nested-card-tabbed/tab.html htmlid=apache_htmlid is_active_tab=true tab_title="Using Kroxylicious with the Apache Kafka® command line clients" %}
 {% include nested-card-tabbed/tab.html htmlid=kaf_htmlid is_active_tab=false tab_title="Using Kroxylicious with the [Kaf](https://github.com/birdayz/kaf) command line client" %}
 {% endcapture %}
 

--- a/docs/quickstart/deploy/index.markdown
+++ b/docs/quickstart/deploy/index.markdown
@@ -1,17 +1,15 @@
 ---
-htmlid: deploy
-tab_title: Deployment
+layout: quickstart
+title: Deployment quickstart
 ---
 Kroxylicious is a Java application based on [Netty](https://netty.io/), which means it will run anywhere you can run a JVM. (That's a lot of places!)
 To help you get started with Kroxylicious, we've created this quick setup guide.
 
-<br />
+# Getting started
 
-<h1 id="getting-started-deployment">Getting started</h1>
+## Prerequisites
 
-<h2 class="fs-3" id="prerequisites-deployment">Prerequisites</h2>
-
-<h3 class="fs-4" id="java-deployment">Java</h3>
+### Java
 
 To get started deploying Kroxylicious, you will need to install a Java Runtime Environment (JRE) with minimum version 17. This does not come included with Kroxylicious.
 
@@ -27,15 +25,13 @@ If you get an error or the command doesn't return anything, you may not have a J
 
 {% include bs-alert.html type="primary" icon="info-circle-fill" content=jre_note %}
 
-<h3 class="fs-4" id="apache-kafka-deployment">Apache Kafka&#174;</h3>
+### Apache Kafka®
 
-You will also need a running Apache Kafka&#174; cluster for Kroxylicious to proxy. The official Apache Kafka&#174; [quickstart](https://kafka.apache.org/documentation/#quickstart) has instructions for setting up a local bare metal cluster.
+You will also need a running Apache Kafka® cluster for Kroxylicious to proxy. The official Apache Kafka® [quickstart](https://kafka.apache.org/documentation/#quickstart) has instructions for setting up a local bare metal cluster.
 
 Once your cluster is set up, the cluster bootstrap address used by Kroxylicious can be changed in the configuration YAML file (see the [**Configure**](#configure-deployment) section below).
 
-<br />
-
-<h2 class="fs-3" id="downloading-kroxylicious-deployment">Downloading Kroxylicious</h2>
+## Downloading Kroxylicious
 
 Kroxylicious can be downloaded from the [releases](https://github.com/kroxylicious/kroxylicious/releases) page of the Kroxylicious GitHub repository, or from Maven Central.
 
@@ -47,16 +43,12 @@ If you're trying Kroxylicious out on Linux or macOS, you may find the `.tar.gz` 
 
 {% include bs-alert.html type="primary" icon="info-circle-fill" content=os_archive_note %}
 
-<br />
-
-<h1 id="install-deployment">Install</h1>
+# Install
 
 Extract the downloaded Kroxylicious Zip file into the directory you would like to install Kroxylicious in.
 Ensure the `kroxylicious-start.sh` and `run-java.sh` files in the `bin/` directory within the extracted folder have at least read and execute (`r-x`) permissions for the owner.
 
-<br />
-
-<h1 id="configure-deployment">Configure</h1>
+# Configure
 
 Kroxylicious is configured with YAML. From the configuration file you can specify how Kroxylicious presents each Apache Kafka&#174; broker to clients, where Kroxylicious will locate the Apache Kafka&#174; cluster(s) to be proxied, and which filters Kroxylicious should use along with any configuration for those filters.
 
@@ -66,9 +58,7 @@ For this quickstart we will use Kroxylicious in Port-Per-Broker configuration, a
 
 If your machine uses a non-standard port configuration, or if you have used custom settings for your Apache Kafka&#174; cluster (or if your cluster is running on a different machine) you will need to adjust your Kroxylicious configuration accordingly. More information about configuring Kroxylicious can be found in the [documentation](https://kroxylicious.io/kroxylicious/#_deploying_proxies).
 
-<br />
-
-<h1 id="run-deployment">Run</h1>
+# Run
 
 From within the extracted Kroxylicious folder, run the following command:
 
@@ -78,9 +68,7 @@ From within the extracted Kroxylicious folder, run the following command:
 
 To use your own configuration file instead of the example, just replace the file path after `--config`.
 
-<br />
-
-<h1 id="use-deployment">Use</h1>
+# Use
 
 To use your Kroxylicious proxy, your client(s) will need to point to the proxy (using the configured address) rather than directly at the Apache Kafka&#174; cluster.
 
@@ -95,25 +83,19 @@ To use your Kroxylicious proxy, your client(s) will need to point to the proxy (
 {% capture apacheClientContent %}
 In each command below, substitute `$KROXYLICIOUS_BOOTSTRAP` for the bootstrap address of your Kroxylicious instance.
 
-<br />
-
-<h2 class="fs-5">1. Create a topic via Kroxylicious</h2>
+## 1. Create a topic via Kroxylicious
 Create a topic called "my_topic" using the `kafka-topics.sh` command line client:
 ```shell
 bin/kafka-topics.sh --create --topic my_topic --bootstrap-server $KROXYLICIOUS_BOOTSTRAP
 ```
 
-<br />
-
-<h2 class="fs-5">2. Produce a string to your topic via Kroxylicious</h2>
+## 2. Produce a string to your topic via Kroxylicious
 Produce the string "hello world" to your new topic using the `kafka-console-producer.sh` command line client:
 ```shell
 echo "hello world" | bin/kafka-console-producer.sh --topic my_topic --bootstrap-server $KROXYLICIOUS_BOOTSTRAP
 ```
 
-<br />
-
-<h2 class="fs-5">3. Consume your string from your topic via Kroxylicious</h2>
+## 3. Consume your string from your topic via Kroxylicious
 Consume your string ("hello world") from your topic ("my_topic") using the `kafka-console-consumer.sh` command line client:
 ```shell
 bin/kafka-console-consumer.sh --topic my_topic --from-beginning --bootstrap-server $KROXYLICIOUS_BOOTSTRAP
@@ -123,25 +105,19 @@ bin/kafka-console-consumer.sh --topic my_topic --from-beginning --bootstrap-serv
 {% capture kafClientContent %}
 In each command below, substitute `$KROXYLICIOUS_BOOTSTRAP` for the bootstrap address of your Kroxylicious instance.
 
-<br />
-
-<h2 class="fs-5">1. Create a topic with Kaf via Kroxylicious</h2>
+## 1. Create a topic with Kaf via Kroxylicious
 Create a topic called "my_topic" using Kaf:
 ```shell
 kaf -b $KROXYLICIOUS_BOOTSTRAP topic create my_topic
 ```
 
-<br />
-
-<h2 class="fs-5">2. Produce a string to your topic with Kaf via Kroxylicious</h2>
+## 2. Produce a string to your topic with Kaf via Kroxylicious
 Produce the string "hello world" to your new topic:
 ```shell
 echo "hello world" | kaf -b $KROXYLICIOUS_BOOTSTRAP produce my_topic
 ```
 
-<br />
-
-<h2 class="fs-5">3. Consume your string from your topic with Kaf via Kroxylicious</h2>
+## 3. Consume your string from your topic with Kaf via Kroxylicious
 Consume your string ("hello world") from your topic ("my_topic"):
 ```shell
 kaf -b $KROXYLICIOUS_BOOTSTRAP consume my_topic

--- a/docs/quickstart/develop/index.markdown
+++ b/docs/quickstart/develop/index.markdown
@@ -1,7 +1,10 @@
 ---
 layout: quickstart
-title: Development quickstart
+title: Developer quickstart
 ---
+
+This quick start will guide you through developing a filter for the proxy.
+
 Kroxylicious' composable filter chains and pluggable API mean that you can write your own filters to apply your own rules to the Kafka protocol.
 
 In this quickstart you will build a custom filter and use it to modify messages being sent to/consumed from Kafka, learn about filter configuration and running custom filters, and find a starting point for developing your own custom filters with your own rules and logic.

--- a/docs/quickstart/develop/index.markdown
+++ b/docs/quickstart/develop/index.markdown
@@ -1,6 +1,6 @@
 ---
-htmlid: develop
-tab_title: Development
+layout: quickstart
+title: Development quickstart
 ---
 Kroxylicious' composable filter chains and pluggable API mean that you can write your own filters to apply your own rules to the Kafka protocol.
 

--- a/docs/quickstart/develop/index.markdown
+++ b/docs/quickstart/develop/index.markdown
@@ -1,6 +1,6 @@
 ---
 layout: quickstart
-title: Developer quickstart
+title: Developer quick start
 ---
 
 This quick start will guide you through developing a filter for the proxy.

--- a/docs/quickstart/develop/index.markdown
+++ b/docs/quickstart/develop/index.markdown
@@ -3,25 +3,19 @@ layout: quickstart
 title: Developer quick start
 ---
 
-This quick start will guide you through developing a filter for the proxy.
+Kroxylicious' composable filter chains and pluggable API mean that you can write your own filters to apply your own rules to the Kafka protocol, using the Java programming language.
 
-Kroxylicious' composable filter chains and pluggable API mean that you can write your own filters to apply your own rules to the Kafka protocol.
+In this quick start you will build a custom filter and use it to modify messages being sent to/consumed from Kafka, learn about filter configuration and running custom filters, and find a starting point for developing your own custom filters with your own rules and logic.
 
-In this quickstart you will build a custom filter and use it to modify messages being sent to/consumed from Kafka, learn about filter configuration and running custom filters, and find a starting point for developing your own custom filters with your own rules and logic.
+# Getting started
 
-<br />
-
-<h1 id="getting-started-development">Getting started</h1>
-
-<h2 class="fs-3" id="prerequisites-development">Prerequisites</h2>
+## Prerequisites
 
 To start developing your own custom filters for Kroxylicious, you will need to install [JDK 21](https://openjdk.org/projects/jdk/21/).
 
 You'll also need to install the [Apache Maven CLI](https://maven.apache.org/index.html) and one of either [Podman](https://podman.io/docs/installation) or [Docker](https://docs.docker.com/install/) (Note that if you are using Podman, you may encounter issues with the integration tests. There are instructions [here](https://github.com/kroxylicious/kroxylicious/blob/main/DEV_GUIDE.md#running-integration-tests-on-podman) to resolve this).
 
-<br />
-
-<h2 class="fs-3" id="get-the-code-development">Get the code</h2>
+## Get the code
 
 The easiest way to learn how to build custom filters is with our `kroxylicious-sample` module, which contains some basic find-and-replace filters for you to experiment with.
 Begin by downloading the latest `kroxylicious-sample` sources from the [Kroxylicious repository](https://github.com/kroxylicious/kroxylicious).
@@ -30,9 +24,7 @@ Begin by downloading the latest `kroxylicious-sample` sources from the [Kroxylic
 git clone https://github.com/kroxylicious/kroxylicious.git
 ```
 
-<br />
-
-<h1 id="build-development">Build</h1>
+# Build
 
 Building the sample project is easy! You can build the `kroxylicious-sample` jar either on its own or with the rest of the Kroxylicious project.
 
@@ -48,9 +40,7 @@ Build with the `dist` profile for creating executable JARs:
 mvn verify -Pdist -Dquick
 ```
 
-<br />
-
-<h1 id="run-development">Run</h1>
+# Run
 
 Build both `kroxylicious-sample` and `kroxylicious-app` with the `dist` profile as above, then run the following command:
 
@@ -58,9 +48,7 @@ Build both `kroxylicious-sample` and `kroxylicious-app` with the `dist` profile 
 KROXYLICIOUS_CLASSPATH="kroxylicious-sample/target/*" kroxylicious-app/target/kroxylicious-app-*-bin/kroxylicious-app-*/bin/kroxylicious-start.sh --config kroxylicious-sample/sample-proxy-config.yml
 ```
 
-<br />
-
-<h1 id="configure-development">Configure</h1>
+# Configure
 
 Filters can be added and removed by altering the `filters` list in the `sample-proxy-config.yml` file. You can also reconfigure the sample filters by changing the configuration values in this file.
 
@@ -69,9 +57,7 @@ The **SampleFetchResponseFilter** and **SampleProduceRequestFilter** each have t
 - `findValue` - the string the filter will search for in the produce/fetch data
 - `replacementValue` - the string the filter will replace the value above with
 
-<br />
-
-<h2 class="fs-3" id="default-Configuration-development">Default Configuration</h2>
+## Default Configuration
 
 The default configuration for **SampleProduceRequestFilter** is:
 
@@ -97,8 +83,6 @@ filters:
 
 This means that it will search for the string `bar` in the fetch data and replace all occurrences with the string `baz`. For example, if a Kafka Broker sent a fetch response with data `{"myValue":"bar"}`, the filter would transform this into `{"myValue":"baz"}` and Kroxylicious would send that to the Kafka Consumer instead.
 
-<br />
-
-<h1 id="modify-development">Modify</h1>
+# Modify
 
 Now that you know how the sample filters work, you can start modifying them! Replace the `SampleFilterTransformer` logic with your own code, change which messages they apply to, or whatever else you like!

--- a/quickstarts.markdown
+++ b/quickstarts.markdown
@@ -1,5 +1,0 @@
----
-layout: quickstart
-title: Quickstarts
-permalink: /quickstarts/
----


### PR DESCRIPTION
* Move them from `/quickstarts` to `/doc/quickstart/*/index.markdown`
* Drop the idea of having a tab-per-quickstart. Instead give them each their own page.
* Tweak the scss so the code blocks aren't so huge
* Use markdown syntax for headings
* Drop the `<br/>`