### PR TITLE
Upgrade bootstrap to 5.3.7

### DIFF
--- a/bootstrap_setup.sh
+++ b/bootstrap_setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export BOOTSTRAP_VERSION="5.3.3"
+export BOOTSTRAP_VERSION="5.3.7"
 
 #Remove any existing Bootstrap sources
 rm -f "v$BOOTSTRAP_VERSION.zip"


### PR DESCRIPTION
Fixes some deprecation warnings spewed by jekyll (but not all):

```
Deprecation Warning [mixed-decls]: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
```