### PR TITLE
Use a replacement token for the per-version documentation root

### DIFF
--- a/_data/documentation/0_10_0.yaml
+++ b/_data/documentation/0_10_0.yaml
@@ -3,7 +3,7 @@ docs:
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
-    path: html/proxy-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/proxy-quick-start/
     rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
@@ -13,7 +13,7 @@ docs:
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer
-    path: html/developer-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-quick-start/
     rank: '031'
   - title: Javadoc
     description: The Java API documentation.

--- a/_data/documentation/0_11_0.yaml
+++ b/_data/documentation/0_11_0.yaml
@@ -3,23 +3,23 @@ docs:
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
-    path: html/proxy-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/proxy-quick-start/
     rank: '000'
   - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer
-    path: html/developer-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-quick-start/
     rank: '031'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
     path: /docs/v$(VERSION)/kroxylicious-proxy/
   - title: Operator Guide
     description: Describes how to deploy and operate the proxy on Kubernetes.
-    path: html/operator/
+    path: $(DOC_BASE_FOR_VERSION)/html/operator/
   - title: Developer Guide
     description: Describes how to write Kroxylicious plugins using the Java programming language.
-    path: html/developer/
+    path: $(DOC_BASE_FOR_VERSION)/html/developer/
     rank: '032'
   - title: Javadoc
     description: The Java API documentation.

--- a/_data/documentation/0_12_0.yaml
+++ b/_data/documentation/0_12_0.yaml
@@ -3,7 +3,7 @@ docs:
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
-    path: html/proxy-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/proxy-quick-start/
     rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
@@ -13,7 +13,7 @@ docs:
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer
-    path: html/developer-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-quick-start/
     rank: '031'
   - title: Javadoc
     description: The Java API documentation.

--- a/_data/documentation/0_13_0.yaml
+++ b/_data/documentation/0_13_0.yaml
@@ -3,40 +3,40 @@ docs:
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
-    path: html/proxy-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/proxy-quick-start/
     rank: '000'
   - title: Proxy guide
     description: "Covers using the proxy, including configuration, security and operation."
     tags:
       - proxy
     rank: '010'
-    path: html/kroxylicious-proxy
+    path: $(DOC_BASE_FOR_VERSION)/html/kroxylicious-proxy
   - title: Record Encryption Guide
     description: "Covers using the record encryption filter, including configuration,\
       \ security and operation."
     tags:
       - filter
     rank: '020'
-    path: html/record-encryption-guide
+    path: $(DOC_BASE_FOR_VERSION)/html/record-encryption-guide
   - title: Kroxylicious Operator for Kubernetes
     description: Describes how to deploy and run the Proxy in a Kubernetes environment
       using the Kroxylicious Operator
     tags:
       - kubernetes
     rank: '020'
-    path: html/kroxylicious-operator
+    path: $(DOC_BASE_FOR_VERSION)/html/kroxylicious-operator
   - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer
-    path: html/developer-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-quick-start/
     rank: '031'
   - title: Kroxylicious Developer guide
     description: Covers writing plugins for the proxy in the Java programming language
     tags:
       - developer
     rank: '032'
-    path: html/developer-guide
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-guide
   - title: Kroxylicious Javadocs
     description: The Java API documentation.
     tags:

--- a/_data/documentation/0_14_0-SNAPSHOT.yaml
+++ b/_data/documentation/0_14_0-SNAPSHOT.yaml
@@ -10,21 +10,21 @@ docs:
     tags:
       - proxy
     rank: '010'
-    path: html/kroxylicious-proxy
+    path: $(DOC_BASE_FOR_VERSION)/html/kroxylicious-proxy
   - title: Record Encryption Guide
     description: "Covers using the record encryption filter, including configuration,\
       \ security and operation."
     tags:
       - filter
     rank: '020'
-    path: html/record-encryption-guide
+    path: $(DOC_BASE_FOR_VERSION)/html/record-encryption-guide
   - title: Kroxylicious Operator for Kubernetes
     description: Describes how to deploy and run the Proxy in a Kubernetes environment
       using the Kroxylicious Operator
     tags:
       - kubernetes
     rank: '020'
-    path: html/kroxylicious-operator
+    path: $(DOC_BASE_FOR_VERSION)/html/kroxylicious-operator
   - title: Developer quick start
     description: Start here if you're developing a filter for the first time.
     tags:
@@ -36,7 +36,7 @@ docs:
     tags:
       - developer
     rank: '032'
-    path: html/developer-guide
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-guide
   - title: Kroxylicious Javadocs
     description: The Java API documentation.
     tags:

--- a/_data/documentation/0_1_0.yaml
+++ b/_data/documentation/0_1_0.yaml
@@ -7,7 +7,7 @@ docs:
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer
-    path: html/developer-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-quick-start/
     rank: '031'
   - title: Javadoc
     description: The Java API documentation.

--- a/_data/documentation/0_2_0.yaml
+++ b/_data/documentation/0_2_0.yaml
@@ -7,7 +7,7 @@ docs:
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer
-    path: html/developer-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-quick-start/
     rank: '031'
   - title: Javadoc
     description: The Java API documentation.

--- a/_data/documentation/0_3_0.yaml
+++ b/_data/documentation/0_3_0.yaml
@@ -7,7 +7,7 @@ docs:
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer
-    path: html/developer-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-quick-start/
     rank: '031'
   - title: Javadoc
     description: The Java API documentation.

--- a/_data/documentation/0_4_0.yaml
+++ b/_data/documentation/0_4_0.yaml
@@ -3,7 +3,7 @@ docs:
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
-    path: html/proxy-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/proxy-quick-start/
     rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
@@ -13,7 +13,7 @@ docs:
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer
-    path: html/developer-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-quick-start/
     rank: '031'
   - title: Javadoc
     description: The Java API documentation.

--- a/_data/documentation/0_4_1.yaml
+++ b/_data/documentation/0_4_1.yaml
@@ -3,7 +3,7 @@ docs:
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
-    path: html/proxy-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/proxy-quick-start/
     rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
@@ -13,7 +13,7 @@ docs:
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer
-    path: html/developer-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-quick-start/
     rank: '031'
   - title: Javadoc
     description: The Java API documentation.

--- a/_data/documentation/0_5_0.yaml
+++ b/_data/documentation/0_5_0.yaml
@@ -3,7 +3,7 @@ docs:
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
-    path: html/proxy-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/proxy-quick-start/
     rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
@@ -13,7 +13,7 @@ docs:
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer
-    path: html/developer-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-quick-start/
     rank: '031'
   - title: Javadoc
     description: The Java API documentation.

--- a/_data/documentation/0_5_1.yaml
+++ b/_data/documentation/0_5_1.yaml
@@ -3,7 +3,7 @@ docs:
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
-    path: html/proxy-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/proxy-quick-start/
     rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
@@ -13,7 +13,7 @@ docs:
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer
-    path: html/developer-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-quick-start/
     rank: '031'
   - title: Javadoc
     description: The Java API documentation.

--- a/_data/documentation/0_6_0.yaml
+++ b/_data/documentation/0_6_0.yaml
@@ -3,7 +3,7 @@ docs:
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
-    path: html/proxy-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/proxy-quick-start/
     rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
@@ -13,7 +13,7 @@ docs:
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer
-    path: html/developer-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-quick-start/
     rank: '031'
   - title: Javadoc
     description: The Java API documentation.

--- a/_data/documentation/0_7_0.yaml
+++ b/_data/documentation/0_7_0.yaml
@@ -3,7 +3,7 @@ docs:
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
-    path: html/proxy-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/proxy-quick-start/
     rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
@@ -13,7 +13,7 @@ docs:
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer
-    path: html/developer-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-quick-start/
     rank: '031'
   - title: Javadoc
     description: The Java API documentation.

--- a/_data/documentation/0_8_0.yaml
+++ b/_data/documentation/0_8_0.yaml
@@ -3,7 +3,7 @@ docs:
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
-    path: html/proxy-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/proxy-quick-start/
     rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
@@ -13,7 +13,7 @@ docs:
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer
-    path: html/developer-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-quick-start/
     rank: '031'
   - title: Javadoc
     description: The Java API documentation.

--- a/_data/documentation/0_9_0.yaml
+++ b/_data/documentation/0_9_0.yaml
@@ -3,7 +3,7 @@ docs:
     description: Start here if you're experimenting with the proxy for the first time.
     tags:
       - proxy
-    path: html/proxy-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/proxy-quick-start/
     rank: '000'
   - title: Proxy Guide
     description: Describes how to deploy and operate the proxy on "bare metal".
@@ -13,7 +13,7 @@ docs:
     description: Start here if you're developing a filter for the first time.
     tags:
       - developer
-    path: html/developer-quick-start/
+    path: $(DOC_BASE_FOR_VERSION)/html/developer-quick-start/
     rank: '031'
   - title: Javadoc
     description: The Java API documentation.

--- a/_layouts/released-documentation.html
+++ b/_layouts/released-documentation.html
@@ -38,18 +38,11 @@ layout: default
     <div class="row row-cols-1 row-cols-md-2 g-4">
 {%- assign docs_for_release = site.data.documentation[underscored_version].docs | sort: "rank" -%}
 {%- for doc in docs_for_release -%}
-{%- assign first1 = doc.path | slice: 0, 1 -%}
-{%- assign first7 = doc.path | slice: 0, 7 -%}
-{%- assign first8 = doc.path | slice: 0, 8 -%}
-{%- if first7 == 'http://' or first8 == 'https://' or first1 == '/' -%}
-{%- assign pathPrefix = "" -%}
-{%- else -%} 
-{%- assign pathPrefix = "/documentation/" | append: version | append: "/" -%}
-{%- endif -%}
+{%- assign docBaseForVersion = "/documentation/" | append: version -%}
       <div class="col">
         <div class="card shadow mb-2 h-100 mx-2 {%- for tag in doc.tags %} doctag-{{tag}}{%- endfor -%}">
           <div class="card-header">
-            <h2 class="card-title fs-4"><a href='{{ pathPrefix }}{{ doc.path | replace: "$(VERSION)", version}}'>{{ doc.title }}</a></h2>
+            <h2 class="card-title fs-4"><a href='{{ doc.path | replace: "$(VERSION)", version | replace: "$(DOC_BASE_FOR_VERSION)", docBaseForVersion}}'>{{ doc.title }}</a></h2>
           </div>
           <div class="card-body mx-3 my-2">
 {{ doc.description }}


### PR DESCRIPTION
If a documentation path contains $(DOC_BASE_FOR_VERSION) we replace this with `/documentation/$(version)`

Why

Previously, if the path did not start with "http://" or "https://" or "/", we inferred that it is relative to the per-version documentation dir. A path of `html/123` for version 0.13.0 would be expanded to: documentation/0.13.0/html/123.

Using a replacement names this concept and trims down the templating code to not need to check the path prefixes.