### PR TITLE
[Docs] Matching actual config file name in the quick start

### DIFF
--- a/documentation/0.13.0/html/proxy-quick-start/index.markdown
+++ b/documentation/0.13.0/html/proxy-quick-start/index.markdown
@@ -71,7 +71,7 @@ More information about configuring Kroxylicious can be found in the [documentati
 From within the extracted Kroxylicious folder, run the following command:
 
 ```shell
-./bin/kroxylicious-start.sh --config config/example-proxy-config.yml
+./bin/kroxylicious-start.sh --config config/example-proxy-config.yaml
 ```
 
 To use your own configuration file instead of the example, just replace the file path after `--config`.


### PR DESCRIPTION
@tombentley, minor issue as I'm running through the quickstart.