### PR TITLE
Add CI to check that we can build the production site

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,41 @@
+name: Test PR
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          # this is required for the subsequent build to be able to push to the registry on localhost:5000
+          driver-opts: network=host
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: localhost:5000/kroxy-jekyll:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+ 
+      - name: Build with Jekyll
+        run: |
+          docker run \
+            --rm \
+            -u "$(id -u):$(id -g)" \
+            -v "$(pwd):/site" \
+            localhost:5000/kroxy-jekyll:latest \
+            bash -c 'eval "$(rbenv init -)" && cp -r /css/_sass/bootstrap /site/_sass/ && JEKYLL_ENV=production bundle exec jekyll build --config=_config.yml'

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
                    wget \
                    golang && \
                    rm -rf /var/lib/apt/lists/*
-ENV RBENV_ROOT /usr/local/rbenv
+ENV RBENV_ROOT=/usr/local/rbenv
 RUN git clone https://github.com/rbenv/rbenv.git ${RBENV_ROOT} && \
     git clone https://github.com/rbenv/ruby-build.git ${RBENV_ROOT}/plugins/ruby-build
 
@@ -45,4 +45,4 @@ RUN mkdir /site/
 WORKDIR /site/
 EXPOSE 4000
 # Note --incremental mode is ineffective on the Mac owing to https://github.com/containers/podman/issues/22343.  Use force_regenerate.sh to trigger the incremental reload after changing the file on the host.
-CMD eval "$(rbenv init -)" && cp -r /css/_sass/bootstrap /site/_sass/ && bundle exec jekyll serve --host ${JEKYLL_SERVE_BIND} --incremental --disable-disk-cache --destination /tmp/site
+CMD [ "bash", "-c", "eval \"$(rbenv init -)\" && cp -r /css/_sass/bootstrap /site/_sass/ && bundle exec jekyll serve --host ${JEKYLL_SERVE_BIND} --incremental --disable-disk-cache --destination /tmp/site"]


### PR DESCRIPTION
This adds a separate workflow for PR CI, just checking we can build the site in production mode. We might need an accompanying change in the settings to require the checks to succeed before users can merge PRs.

The workflow is similar to the automation that deploys the website to GitHub Pages, but I made it a separate workflow as I'm envisaging adding specializations here. Like if there is any linting or simple tests we want to execute against the built site HTML we could do them in this workflow without riddling the prod deploy workflow with conditionals.