### PR TITLE
Fix documentation/download/release-archive internal links to work with non-empty baseurl

### DIFF
--- a/_layouts/download-release.html
+++ b/_layouts/download-release.html
@@ -30,7 +30,7 @@ layout: default
           </div>
 {%- endif -%}
 </p>
-<p>See the <a href="/release-archives/">release archives</a> for other releases.</p>
+<p>See the <a href="{{ '/release-archives/' | absolute_url }}">release archives</a> for other releases.</p>
       </div>
     </div>
   </div>
@@ -53,7 +53,7 @@ layout: default
           <div class="col">
               <div class="card shadow mb-2 h-100 mx-2">
                   <div class="card-header">
-                      <h2 class="card-title fs-4"><a href="/documentation/{{ releaseVersion }}/">Documentation and quick starts</a></h2>
+                      <h2 class="card-title fs-4"><a href="{{ '/documentation/' | append: releaseVersion | append: '/' | absolute_url }}">Documentation and quick starts</a></h2>
                   </div>
                   <div class="card-body mx-3 my-2">
                       Learn how to use what you're downloading.

--- a/_layouts/released-documentation.html
+++ b/_layouts/released-documentation.html
@@ -41,15 +41,17 @@ layout: default
 {%- assign first1 = doc.path | slice: 0, 1 -%}
 {%- assign first7 = doc.path | slice: 0, 7 -%}
 {%- assign first8 = doc.path | slice: 0, 8 -%}
-{%- if first7 == 'http://' or first8 == 'https://' or first1 == '/' -%}
-{%- assign pathPrefix = "" -%}
+{%- if first7 == 'http://' or first8 == 'https://' -%}
+{%- assign linkTemplate = doc.path -%}
+{%- elsif first1 == '/' -%}
+{%- assign linkTemplate = doc.path | absolute_url -%}
 {%- else -%} 
-{%- assign pathPrefix = "/documentation/" | append: version | append: "/" -%}
+{%- assign linkTemplate = "/documentation/" | append: version | append: "/" | append: doc.path | absolute_url -%}
 {%- endif -%}
       <div class="col">
         <div class="card shadow mb-2 h-100 mx-2 {%- for tag in doc.tags %} doctag-{{tag}}{%- endfor -%}">
           <div class="card-header">
-            <h2 class="card-title fs-4"><a href='{{ pathPrefix }}{{ doc.path | replace: "$(VERSION)", version}}'>{{ doc.title }}</a></h2>
+            <h2 class="card-title fs-4"><a href='{{ linkTemplate | replace: "$(VERSION)", version}}'>{{ doc.title }}</a></h2>
           </div>
           <div class="card-body mx-3 my-2">
 {{ doc.description }}

--- a/_layouts/released-documentation.html
+++ b/_layouts/released-documentation.html
@@ -30,7 +30,7 @@ layout: default
           </div>
 {%- endif -%}
 </p>
-<p>See the <a href="/release-archives/">release archives</a> for the documentation of other releases.</p>
+<p>See the <a href="{{ '/release-archives/' | absolute_url }}">release archives</a> for the documentation of other releases.</p>
       </div>
     </div>
   </div>

--- a/release-archives/index.md
+++ b/release-archives/index.md
@@ -31,8 +31,8 @@ title: Release Archives
 <h2 id="{{ releaseVersion }}" class="card-title fs-4">{{ releaseVersion }}
 {%- if releaseVersion == site.data.kroxylicious.latestRelease %} (latest release){%- endif -%}
 </h2>
-<a href="/documentation/{{ releaseVersion }}/">Documentation</a><br/>
-<a href="/download/{{ releaseVersion }}/">Download</a>
+<a href="{{ '/documentation/' | append: releaseVersion | append: '/' | absolute_url }}">Documentation</a><br/>
+<a href="{{ '/download/' | append: releaseVersion | append: '/' | absolute_url }}">Download</a>
       </div>
     </div>
 {%- endfor -%}


### PR DESCRIPTION
Deploying on a fork is useful to exercise the github actions if we are working on the build aspects of this repo and it makes it easier to share WIP when hacking on the website. Our forks typically will look like `https://<user>.github.io/kroxylicious.github.io` where the main website is deployed to `https://kroxylicious.io` without any baseurl.

To run on a fork with a base url like https://kroxylicious.io/kroxylicious/ we need the links to all be aware of the baseurl, we have a mixture currently, some work and some don't.

This fixes up:
1. links from the release-archives to the docs/downloads
2. links from the released-documentation pages to the release-archives
3. relative/domain-relative links on the released-documentation pages
4. links from the download-release pages to the release-archive
5. links from the download-release page to the documentation for that release

On the released-documentation pages:
* links that are already absolute are not modified
* links starting with '/' are converted to absolute
* other links are assumed to be relative to the per-release data, we construct this and then convert to an absolute url

To test you can set `baseurl` to `kroxylicious` in _config.yml and run `run.sh`, then navigate to http://localhost:4000/kroxylicious/documentation/ or http://localhost:4000/kroxylicious/documentation/0.13.0/ or  https://kroxylicious.io/release-archives/