### PR TITLE
Add run-snapshot.sh script

### DIFF
--- a/run-snapshot.sh
+++ b/run-snapshot.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# This script builds the documentation in a local checkout of the kroxylicious/kroxylicious repository, then incorporates
+# the built documentation into a local deployment of the website and serves it on localhost:4000 using ./run.sh.
+#
+# It is assumed this repository is checked out beside a cloned https://github.com/kroxylicious/kroxylicious/ like:
+# .
+# ├── kroxylicious
+# └── kroxylicious.github.io
+# 
+# if you organize your directories differently, you can set the KROXYLICIOUS_DIR env variable like
+# KROXYLICIOUS_DIR=/path/to/my/kroxylicious ./run-snapshot.sh to point it at your kroxylicious dir.
+
+trap "exit" INT
+set +euo pipefail
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+KROXYLICIOUS_DIR="${KROXYLICIOUS_DIR:-${SCRIPT_DIR}/../kroxylicious}"
+TEST_FILE="${KROXYLICIOUS_DIR}/pom.xml"
+if [ ! -f "${TEST_FILE}" ]; then
+  echo "${TEST_FILE} not found, set KROXYLICIOUS_DIR env var to point to a checkout of https://github.com/kroxylicious/kroxylicious"
+  exit 1
+fi
+
+cd ${KROXYLICIOUS_DIR}
+mvn -Dquick -P dist clean package --non-recursive
+cp -r target/web/* ${SCRIPT_DIR}
+cd ${SCRIPT_DIR}
+exec ./run.sh


### PR DESCRIPTION
Why:
I'm working on the API between the kroxylicious/kroxylicious repository and this repository. This script is a convenient way to incorporate a fresh build of 'target/web' in kroxylicious and run up the development server.