### PR TITLE
Fix download links in older releases

### DIFF
--- a/_data/release/0_10_0.yaml
+++ b/_data/release/0_10_0.yaml
@@ -1,4 +1,4 @@
-assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
+assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)/
 assets:
   - name: Proxy
     description: The proxy application.

--- a/_data/release/0_11_0.yaml
+++ b/_data/release/0_11_0.yaml
@@ -1,4 +1,4 @@
-assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
+assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)/
 assets:
   - name: Proxy
     description: The proxy application.

--- a/_data/release/0_1_0.yaml
+++ b/_data/release/0_1_0.yaml
@@ -1,4 +1,4 @@
-assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
+assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)/
 assets:
   - name: Proxy
     description: The proxy application.

--- a/_data/release/0_2_0.yaml
+++ b/_data/release/0_2_0.yaml
@@ -1,4 +1,4 @@
-assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
+assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)/
 assets:
   - name: Proxy
     description: The proxy application.

--- a/_data/release/0_3_0.yaml
+++ b/_data/release/0_3_0.yaml
@@ -1,4 +1,4 @@
-assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
+assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)/
 assets:
   - name: Proxy
     description: The proxy application.

--- a/_data/release/0_4_0.yaml
+++ b/_data/release/0_4_0.yaml
@@ -1,4 +1,4 @@
-assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
+assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)/
 assets:
   - name: Proxy
     description: The proxy application.

--- a/_data/release/0_4_1.yaml
+++ b/_data/release/0_4_1.yaml
@@ -1,4 +1,4 @@
-assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
+assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)/
 assets:
   - name: Proxy
     description: The proxy application.

--- a/_data/release/0_5_0.yaml
+++ b/_data/release/0_5_0.yaml
@@ -1,4 +1,4 @@
-assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
+assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)/
 assets:
   - name: Proxy
     description: The proxy application.

--- a/_data/release/0_5_1.yaml
+++ b/_data/release/0_5_1.yaml
@@ -1,4 +1,4 @@
-assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
+assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)/
 assets:
   - name: Proxy
     description: The proxy application.

--- a/_data/release/0_6_0.yaml
+++ b/_data/release/0_6_0.yaml
@@ -1,4 +1,4 @@
-assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
+assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)/
 assets:
   - name: Proxy
     description: The proxy application.

--- a/_data/release/0_7_0.yaml
+++ b/_data/release/0_7_0.yaml
@@ -1,4 +1,4 @@
-assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
+assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)/
 assets:
   - name: Proxy
     description: The proxy application.

--- a/_data/release/0_8_0.yaml
+++ b/_data/release/0_8_0.yaml
@@ -1,4 +1,4 @@
-assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
+assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)/
 assets:
   - name: Proxy
     description: The proxy application.

--- a/_data/release/0_9_0.yaml
+++ b/_data/release/0_9_0.yaml
@@ -1,4 +1,4 @@
-assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)
+assetBaseUrl: https://github.com/kroxylicious/kroxylicious/releases/tag/v$(VERSION)/
 assets:
   - name: Proxy
     description: The proxy application.


### PR DESCRIPTION
Older releases than 0.12.0 have broken links to their asset files. Eg

https://kroxylicious.io/download/0.11.0/

https://github.com/kroxylicious/kroxylicious/releases/tag/v0.11.0kroxylicious-app-0.11.0-bin.zip