### PR TITLE
Add build script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .jekyll-cache
 .gitignore
 run.sh
+build.sh
 Dockerfile
 .dockerignore
 .git

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -63,16 +63,13 @@ jobs:
         # this is to enable forks to override the url and baseurl
         run: echo "${{ vars.JEKYLL_CONFIG_OVERRIDES }}" > _config-overrides.yml
       - name: Build with Jekyll
-        # Outputs to the './_site' directory by default
+        # Outputs to the './_site' directory
         run: |
-          docker run \
-            --rm \
-            -u "$(id -u):$(id -g)" \
-            -v "$(pwd):/site" \
-            localhost:5000/kroxy-jekyll:latest \
-            bash -c 'eval "$(rbenv init -)" && cp -r /css/_sass/bootstrap /site/_sass/ && JEKYLL_ENV=production bundle exec jekyll build --config=_config.yml,_config-overrides.yml'
+          ./build.sh
         env:
-          JEKYLL_ENV: production
+          CONTAINER_ENGINE: docker
+          CONFIG_OVERRIDES: _config-overrides.yml
+          BUILD_IMAGE_SPEC: localhost:5000/kroxy-jekyll:latest
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -32,10 +32,9 @@ jobs:
           cache-to: type=gha,mode=max
  
       - name: Build with Jekyll
+        # Outputs to the './_site' directory
         run: |
-          docker run \
-            --rm \
-            -u "$(id -u):$(id -g)" \
-            -v "$(pwd):/site" \
-            localhost:5000/kroxy-jekyll:latest \
-            bash -c 'eval "$(rbenv init -)" && cp -r /css/_sass/bootstrap /site/_sass/ && JEKYLL_ENV=production bundle exec jekyll build --config=_config.yml'
+          ./build.sh
+        env:
+          CONTAINER_ENGINE: docker
+          BUILD_IMAGE_SPEC: localhost:5000/kroxy-jekyll:latest

--- a/README.md
+++ b/README.md
@@ -23,13 +23,27 @@ We don't use the Bootstrap 5 ruby gem here, as it runs on a
 
 ### Running in a Container
 
+When developing website content (editing markdown/asciidoc, modifying ruby extensions) it is useful to deploy a
+local testing server that presents the website, with hot-reloading so that source changes are reflected quickly
+in the built HTML.
+
 To build and serve the website from a container you can run `./run.sh`. It will be deployed on http://localhost:4000
 
 This assumes the use of `podman`, if you are a `docker` user you can run `CONTAINER_ENGINE=docker ./run.sh`.
 
+### Building Production HTML
+
+When developing build automation, it is useful to be able to build the static website output, that will be deployed to production, the
+same way it will be built in GitHub Actions.
+
+To build the production site you can run `./build.sh` which will produce an `_site` directory containing the built website for production.
+
+This assumes the use of `podman`, if you are a `docker` user you can run `CONTAINER_ENGINE=docker ./build.sh`.
+
 ### Running on GitHub Pages on a Fork
 
-To exercise the GitHub workflows and share changes it can be convenient to deploy a fork to GitHub Pages.
+When developing build automation, it is useful to be able to deploy your changes to the GitHub Pages a Fork of this repository. This
+exercises all the production artifact creation and Pages deployment parts of the automation.
 
 To enable pages on your fork:
 1. go to `https://github.com/${yourname}/kroxylicious.github.io/settings` in a browser, replacing `${yourname}` with your GitHub username.

--- a/_config.yml
+++ b/_config.yml
@@ -47,6 +47,7 @@ exclude:
   - .idea
   - docs/README.md
   - Dockerfile
+  - build.sh
   - run.sh
   - bootstrap_setup.sh
   - README.md

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This script exists to run a production build of the code. Users can:
+# * Supply a builder image with BUILD_IMAGE_SPEC, otherwise we build the image
+# * Include additional configuration overrides with ${CONFIG_OVERRIDES}, additional
+#   override files should be added to the project directory. Eg I add an _config-overrides.yml
+#   and set CONFIG_OVERRIDES=_config-overrides.yml
+# * Control their container engine binary by setting CONTAINER_ENGINE, for example to 'docker'.
+# The output of the build will be emitted to a '_site' directory in the project directory
+trap "exit" INT
+set +euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd ${SCRIPT_DIR}
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-podman}
+if [ -z "${BUILD_IMAGE_SPEC}" ]; then
+  ${CONTAINER_ENGINE} build . -t kroxylicious-website
+  export BUILD_IMAGE_SPEC=kroxylicious-website
+fi
+if [ -n "${CONFIG_OVERRIDES}" ]; then
+  export CONFIG_OVERRIDES=",${CONFIG_OVERRIDES}"
+else
+  export CONFIG_OVERRIDES=""
+fi
+RUN_ARGS=()
+if [ "$CONTAINER_ENGINE" = 'podman' ]; then
+  RUN_ARGS+=(-v "$(pwd):/site/:Z")
+else
+  RUN_ARGS+=(-v "$(pwd):/site")
+  RUN_ARGS+=(-u $(id -u):$(id -g))
+fi
+RUN_ARGS+=(-e JEKYLL_ENV="${JEKYLL_ENV:-production}" --rm "${BUILD_IMAGE_SPEC}")
+BUILD_COMMAND='eval "$(rbenv init -)" && cp -r /css/_sass/bootstrap /site/_sass/ && bundle exec jekyll build --config=_config.yml'"${CONFIG_OVERRIDES}"
+RUN_ARGS+=(bash -c "${BUILD_COMMAND}")
+echo "${RUN_ARGS[@]}"
+${CONTAINER_ENGINE} run "${RUN_ARGS[@]}"


### PR DESCRIPTION
Add a build script so that we can build the same way locally and in CI

I'm experimenting with some automation for checking that all the links within the generated HTML are valid, having a way to produce the production build output locally is helpful.