### PR TITLE
Add bottom padding to code blocks in the kroxylicious documentation

### DIFF
--- a/_sass/kroxylicious.scss
+++ b/_sass/kroxylicious.scss
@@ -306,3 +306,7 @@ b.conum * {
   
   pointer-events: none; /* Clicks will "pass through" the watermark */
 }
+
+.listingblock {
+  margin-bottom: 0.75rem;
+}


### PR DESCRIPTION
codeblocks imported from the runtime repository are cramped up, lets give them some padding

## before

<img width="1034" height="920" alt="Screenshot From 2025-08-05 16-04-07" src="https://github.com/user-attachments/assets/a154a6d4-e190-4f72-aa40-88ae6137ddc4" />

## after

<img width="1034" height="920" alt="Screenshot From 2025-08-05 16-03-36" src="https://github.com/user-attachments/assets/bd0e1367-9893-4482-ac1c-3b0823f2bb7c" />

