### PR TITLE
Use a boring old table for documentation links

### DIFF
--- a/_layouts/released-documentation.html
+++ b/_layouts/released-documentation.html
@@ -35,7 +35,12 @@ layout: default
     </div>
   </div>
   <div class="col-lg-6" role="main">
-    <div class="row row-cols-1 row-cols-md-2 g-4">
+    <div class="row">
+    <table class="table">
+      <thead>
+      <tr><th class="col-lg-2">Document</th><th class="col-lg-4">Description</th></tr>
+      </thead>
+      <tbody>
 {%- assign docs_for_release = site.data.documentation[underscored_version].docs | sort: "rank" -%}
 {%- for doc in docs_for_release -%}
 {%- assign first1 = doc.path | slice: 0, 1 -%}
@@ -48,18 +53,17 @@ layout: default
 {%- else -%} 
 {%- assign linkTemplate = "/documentation/" | append: version | append: "/" | append: doc.path | absolute_url -%}
 {%- endif -%}
-      <div class="col">
-        <div class="card shadow mb-2 h-100 mx-2 {%- for tag in doc.tags %} doctag-{{tag}}{%- endfor -%}">
-          <div class="card-header">
-            <h2 class="card-title fs-4"><a href='{{ linkTemplate | replace: "$(VERSION)", version}}'>{{ doc.title }}</a></h2>
-          </div>
-          <div class="card-body mx-3 my-2">
+      <tr>
+          <td>
+            <a href='{{ linkTemplate | replace: "$(VERSION)", version}}'>{{ doc.title }}</a>
+          </td>
+          <td>
 {{ doc.description }}
-          </div>
-        </div>
-      </div>
+          </td>
+      </tr>
 {%- endfor -%}
-    </div>
+      </tbody>
+  </table>
   </div>
 </div>
 


### PR DESCRIPTION
Cards were getting big v0.14.0 is going to introduce even more. Even nicer might be a tree like arrangement with quickstarts/guides/other grouped together.

Before:
<img width="1442" height="854" alt="Screenshot From 2025-08-05 17-24-40" src="https://github.com/user-attachments/assets/9ea7395f-ef67-4ed3-88b5-32f8d8e462e8" />

After:
<img width="1442" height="854" alt="Screenshot From 2025-08-05 17-23-37" src="https://github.com/user-attachments/assets/57712c62-8e87-416e-a1ee-8779d4a4abe3" />
