### PR TITLE
Fix quickstart ports

### DIFF
--- a/documentation/0.14.0/html/proxy-quick-start/content.html
+++ b/documentation/0.14.0/html/proxy-quick-start/content.html
@@ -159,7 +159,7 @@ podman run -p 9092:9092 apache/kafka:4.0.0</code></pre>
      <div class="listingblock">
       <div class="content">
        <pre class="CodeRay highlight"><code data-lang="bash">bin/kafka-topics.sh --create --topic my_topic \
---bootstrap-server localhost:9292</code></pre>
+--bootstrap-server localhost:9192</code></pre>
       </div>
      </div>
     </div>
@@ -171,7 +171,7 @@ podman run -p 9092:9092 apache/kafka:4.0.0</code></pre>
      <div class="listingblock">
       <div class="content">
        <pre class="CodeRay highlight"><code data-lang="bash">echo "hello world" | bin/kafka-console-producer.sh --topic my_topic \
---bootstrap-server localhost:9292</code></pre>
+--bootstrap-server localhost:9192</code></pre>
       </div>
      </div>
     </div>
@@ -183,7 +183,7 @@ podman run -p 9092:9092 apache/kafka:4.0.0</code></pre>
      <div class="listingblock">
       <div class="content">
        <pre class="CodeRay highlight"><code data-lang="bash">bin/kafka-console-consumer.sh --topic my_topic --from-beginning \
---bootstrap-server localhost:9292</code></pre>
+--bootstrap-server localhost:9192</code></pre>
       </div>
      </div>
     </div>


### PR DESCRIPTION
yarg, the proxy starts on 9192 by default:

```
2025-08-08 16:25:20 <main> INFO  io.kroxylicious.proxy.model.VirtualClusterModel - Gateway: mygateway, Downstream localhost:9192 => Upstream localhost:9092
```

```
...snip ...
    - name: mygateway
      portIdentifiesNode:
        bootstrapAddress: localhost:9192
```