### PR TITLE
Add contribution section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@ This is the repo containing the kroxylicious.io website.
 The site runs on Jekyll, so you'll need to ensure you have the [prerequisites](https://jekyllrb.com/docs/) installed to try it locally.
 You'll also need to ensure you have Ruby 3.2+ installed, along with the latest versions of Rake and Bundler for your Ruby distribution.
 
+<!-- TOC -->
+* [Kroxylicous.io Site](#kroxylicousio-site)
+  * [What?](#what)
+  * [Key Files](#key-files)
+  * [Development](#development)
+    * [Running in a Container](#running-in-a-container)
+    * [Building Production HTML](#building-production-html)
+    * [Running on GitHub Pages on a Fork](#running-on-github-pages-on-a-fork)
+* [Binary content](#binary-content)
+* [Excalidraw images](#excalidraw-images)
+* [Redirects](#redirects)
+* [Issues](#issues)
+* [Contributing](#contributing)
+<!-- TOC -->
+
 ## Key Files
 - [Gemfile](Gemfile) - required ruby gems for building and serving the site
 - [_config.yml](_config.yml) - Jekyll configuration for building the site
@@ -87,3 +102,11 @@ mappings:
   toVersion: 0.12.0 #Optional, if not specified the latest release at time of site build  is used.
   path: /html/kroxylicious-proxy/#con-configuring-client-connections-proxy # the path within the baseUrl
 ```
+
+# Issues
+
+Issues are tracked in the `kroxylicious/kroxylicious` [Issue tracker](https://github.com/kroxylicious/kroxylicious/issues)
+
+# Contributing
+
+We welcome contributions! Please see our [contributing guidelines](https://github.com/kroxylicious/.github/blob/main/CONTRIBUTING.md) to get started.


### PR DESCRIPTION
We decided that since this repo is quite coupled to the kroxylicious/kroxylicious repo we should have them share an issue tracker, as we regularly triage the main tracker and it generally gets more love.

This change points users at the issue tracker and our other contributing material.