### PR TITLE
Improve guide style

### DIFF
--- a/_layouts/guide.html
+++ b/_layouts/guide.html
@@ -8,7 +8,7 @@ layout: default
     This documentation covers a non-current version of Kroxylicious. The latest version is {{ site.data.kroxylicious.latestRelease }}.
 </div>
 {%- endif -%}
-<div class="row justify-content-center gx-0">
+<div class="row justify-content-center gx-0 kroxylicious-guide">
   <div class="col-lg-3">
     <div class="card shadow my-lg-5 ms-lg-5 me-1">
       <div class="card-body mx-2" role="navigation" aria-label="{{ page.title }} page navigation">

--- a/_sass/kroxylicious.scss
+++ b/_sass/kroxylicious.scss
@@ -161,7 +161,7 @@ a {
 // ensure padding for code blocks
 .highlight {
   text-wrap: wrap;
-  padding: 0.5em;
+  padding: 1rem;
   border-radius: 4px;
   margin-bottom: 0;
 }
@@ -307,10 +307,30 @@ b.conum * {
   pointer-events: none; /* Clicks will "pass through" the watermark */
 }
 
-.imageblock img {
+
+/* Kroxylicious Guide CSS Specializations */
+
+.kroxylicious-guide .imageblock img {
   max-width: 100%;
 }
 
-.listingblock {
+.kroxylicious-guide .listingblock {
   margin-bottom: 0.75rem;
+}
+
+.kroxylicious-guide h2,h3,h4 {
+  margin-top: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.kroxylicious-guide p, summary {
+  margin-bottom: 0.625rem;
+}
+
+.kroxylicious-guide .sect1 {
+  padding-bottom: 1.25rem;
+}
+
+.kroxylicious-guide .sect1+.sect1 {
+  border-top: 1px solid $kroxy-light;
 }


### PR DESCRIPTION
Aligns it more with the standalone asciidoc style, which has much nicer margins/padding and a single pixel top border for main sections, more padding on the codeblocks.

Adds a class to the top div surrounding the content so we can specifically target CSS to the guide content.

## Before
<img width="1125" height="1032" alt="Screenshot From 2025-08-14 16-44-03" src="https://github.com/user-attachments/assets/9c2871f1-ecf6-47a3-8866-27bd24e9ddc4" />

## After
<img width="1125" height="1032" alt="Screenshot From 2025-08-14 16-43-29" src="https://github.com/user-attachments/assets/020eae70-1974-47f1-893b-fa047c4f1f23" />
