### PR TITLE
Tweak community call recordings link

### DIFF
--- a/join-us/community-call/index.md
+++ b/join-us/community-call/index.md
@@ -31,7 +31,7 @@ title: Community call
         <p><a href="https://docs.google.com/document/d/1Kaqe8QZMYlzu72lPCUzlzSLHs7gSSbo44UPOOPqsP4k/edit?usp=sharing" target="_blank" rel="noopener noreferrer" aria-label="Community Call Agenda and Minutes (Google Doc)">
   Community Call Agenda and Minutes
 </a> (read-only).</p>
-        <p>Meetings are recorded and shared on <a href="https://www.youtube.com/@kroxylicious-io">our YouTube channel</a>.</p>
+        <p>Meetings are live streamed and the recordings are shared on <a href="https://www.youtube.com/@kroxylicious-io/streams">our YouTube channel</a>.</p>
       </div>
     </div>
     <div class="d-flex flex-wrap align-items-center justify-content-between mb-4">


### PR DESCRIPTION
The recording are all in the "live" section on you tube, so it would be better to link there directly, than just to the our channel, which includes all the other content too.