### PR TITLE
Update community call to use Google Meet

### DIFF
--- a/community-call.ics
+++ b/community-call.ics
@@ -14,13 +14,9 @@ RRULE:FREQ=WEEKLY;INTERVAL=4;BYDAY=TH
 EXDATE:20261231T080000Z
 SUMMARY:Kroxylicious Community Call
 DESCRIPTION:An opportunity to talk about Kroxylicious with the people working on it.\n
- Click to join: 
- https://meet.jit.si/moderated/87697d32deaa8cbd8b3b96e1
- bbb8aef920c240112935c2d4742c3b1b38a34588 \n
-URL:https://meet.jit.si/moderated/87697d32deaa8cbd8b3b96e1
- bbb8aef920c240112935c2d4742c3b1b38a34588
-LOCATION:https://meet.jit.si/moderated/87697d32deaa8cbd8b3b96e1
- bbb8aef920c240112935c2d4742c3b1b38a34588
+ Click to join: https://meet.google.com/qsi-htyr-phq \n
+URL:https://meet.google.com/qsi-htyr-phq
+LOCATION:https://meet.google.com/qsi-htyr-phq
 END:VEVENT
 BEGIN:VEVENT
 UID:evening-series@kroxylicious.io
@@ -30,12 +26,8 @@ DTEND:20260311T204500Z
 RRULE:FREQ=WEEKLY;INTERVAL=4;BYDAY=WE
 SUMMARY:Kroxylicious Community Call
 DESCRIPTION:An opportunity to talk about Kroxylicious with the people working on it.\n
- Click to join: 
- https://meet.jit.si/moderated/87697d32deaa8cbd8b3b96e1
- bbb8aef920c240112935c2d4742c3b1b38a34588 \n
-URL:https://meet.jit.si/moderated/87697d32deaa8cbd8b3b96e1
- bbb8aef920c240112935c2d4742c3b1b38a34588
-LOCATION:https://meet.jit.si/moderated/87697d32deaa8cbd8b3b96e1
- bbb8aef920c240112935c2d4742c3b1b38a34588
+ Click to join: https://meet.google.com/txh-iuir-jdd \n
+URL:https://meet.google.com/txh-iuir-jdd
+LOCATION:https://meet.google.com/txh-iuir-jdd
 END:VEVENT
 END:VCALENDAR

--- a/join-us/community-call/index.md
+++ b/join-us/community-call/index.md
@@ -24,8 +24,8 @@ title: Community call
   </div>
   <div class="col-lg-6" role="main">
     <div>
-      <p>We're using <a href="https://meet.jit.si/">Jitsi</a>, a free and open source video conferencing service.
-      You don't need an account to join.</p>
+      <p>We're using Google Meet for our community calls.
+      You don't need a Google account to join - you'll be admitted from the waiting room when the moderator starts the call.</p>
       <div class="alert alert-warning" role="alert">
         <h4 class="alert-heading">Meetings are public (and recorded!)</h4>
         <p><a href="https://docs.google.com/document/d/1Kaqe8QZMYlzu72lPCUzlzSLHs7gSSbo44UPOOPqsP4k/edit?usp=sharing" target="_blank" rel="noopener noreferrer" aria-label="Community Call Agenda and Minutes (Google Doc)">

--- a/join-us/community-call/index.md
+++ b/join-us/community-call/index.md
@@ -31,7 +31,7 @@ title: Community call
         <p><a href="https://docs.google.com/document/d/1Kaqe8QZMYlzu72lPCUzlzSLHs7gSSbo44UPOOPqsP4k/edit?usp=sharing" target="_blank" rel="noopener noreferrer" aria-label="Community Call Agenda and Minutes (Google Doc)">
   Community Call Agenda and Minutes
 </a> (read-only).</p>
-        <p>Meetings are live streamed and the recordings are shared on <a href="https://www.youtube.com/@kroxylicious-io/streams">our YouTube channel</a>.</p>
+        <p>Meeting recordings are shared on <a href="https://www.youtube.com/@kroxylicious-io/streams">our YouTube channel</a>.</p>
       </div>
     </div>
     <div class="d-flex flex-wrap align-items-center justify-content-between mb-4">


### PR DESCRIPTION
## Summary
- Switch community call platform from Jitsi to Google Meet
- Update calendar invites (`.ics` file) with new Google Meet URLs for both time slots
- Update web page description to reflect Google Meet and waiting room process

## Context
Aligns with the moderation process change documented in kroxylicious/.github-private#1.

## Test plan
- [ ] Preview the site locally with `./run.sh`
- [ ] Verify calendar invites display correct Google Meet links
- [ ] Verify community call page shows updated text

🤖 Generated with [Claude Code](https://claude.com/claude-code)