### PR TITLE
feat: add release schedule page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -52,6 +52,11 @@
                         </a>
                     </li>
                     <li class="mb-2">
+                        <a class="text-body link-underline-dark link-underline-opacity-0 link-underline-opacity-10-hover" href="{{ '/release-schedule/' | absolute_url }}">
+                            Release Schedule
+                        </a>
+                    </li>
+                    <li class="mb-2">
                         <a class="text-body link-underline-dark link-underline-opacity-0 link-underline-opacity-10-hover" href="{{ '/quickstarts/' | absolute_url }}">
                             Quickstarts
                         </a>

--- a/release-schedule.markdown
+++ b/release-schedule.markdown
@@ -1,0 +1,41 @@
+---
+layout: default
+title: Release Schedule
+permalink: /release-schedule/
+---
+
+<div class="container-xxl krx-gutter py-5">
+  <div class="row">
+    <div class="col">
+      <h1>Release Schedule</h1>
+      <p>This page documents the planned and released versions of Kroxylicious.</p>
+
+      <div class="table-responsive mt-4">
+        <table class="table table-striped table-hover">
+          <thead>
+            <tr>
+              <th scope="col">Release</th>
+              <th scope="col">Planned Release Date</th>
+              <th scope="col">Milestone</th>
+              <th scope="col">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Kroxylicious 0.21.0</td>
+              <td>May 15, 2026</td>
+              <td><a href="https://github.com/kroxylicious/kroxylicious/milestone/27">0.21.0</a></td>
+              <td><span class="badge bg-primary">Planned</span></td>
+            </tr>
+            <tr>
+              <td>Kroxylicious 0.22.0</td>
+              <td>July 3, 2026</td>
+              <td><a href="https://github.com/kroxylicious/kroxylicious/milestone/10">0.22.0</a></td>
+              <td><span class="badge bg-primary">Planned</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Adds a release schedule page to provide visibility into planned and released versions of Kroxylicious. This helps users and contributors track upcoming releases and their target dates.

The page includes milestones linked to GitHub for detailed tracking.

Adds a Footer link

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

<img width="1906" height="921" alt="image" src="https://github.com/user-attachments/assets/5022784b-7979-4bc4-8d12-7b90502bcb53" />
