### PR TITLE
feat: automate release status in schedule

### DIFF
--- a/_data/release-schedule.yml
+++ b/_data/release-schedule.yml
@@ -1,0 +1,7 @@
+releases:
+  - version: 0.21.0
+    plannedDate: May 15, 2026
+    milestoneUrl: https://github.com/kroxylicious/kroxylicious/milestone/27
+  - version: 0.22.0
+    plannedDate: July 3, 2026
+    milestoneUrl: https://github.com/kroxylicious/kroxylicious/milestone/10

--- a/release-schedule.markdown
+++ b/release-schedule.markdown
@@ -21,18 +21,21 @@ permalink: /release-schedule/
             </tr>
           </thead>
           <tbody>
+            {%- for release in site.data.release-schedule.releases -%}
+            {%- assign underscored_version = release.version | replace: '.', '_' -%}
             <tr>
-              <td>Kroxylicious 0.21.0</td>
-              <td>May 15, 2026</td>
-              <td><a href="https://github.com/kroxylicious/kroxylicious/milestone/27">0.21.0</a></td>
-              <td><span class="badge bg-primary">Planned</span></td>
+              <td>Kroxylicious {{ release.version }}</td>
+              <td>{{ release.plannedDate }}</td>
+              <td><a href="{{ release.milestoneUrl }}">{{ release.version }}</a></td>
+              <td>
+                {%- if site.data.release[underscored_version] -%}
+                <span class="badge bg-success">Released</span>
+                {%- else -%}
+                <span class="badge bg-info">Planned</span>
+                {%- endif -%}
+              </td>
             </tr>
-            <tr>
-              <td>Kroxylicious 0.22.0</td>
-              <td>July 3, 2026</td>
-              <td><a href="https://github.com/kroxylicious/kroxylicious/milestone/10">0.22.0</a></td>
-              <td><span class="badge bg-primary">Planned</span></td>
-            </tr>
+            {%- endfor -%}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
Convert release schedule from static HTML to data-driven Liquid templating. Status now automatically changes from "Planned" to "Released" when a release YAML file appears in _data/release/, eliminating manual updates when releases are published.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

<img width="966" height="285" alt="Screenshot From 2026-05-18 16-47-44" src="https://github.com/user-attachments/assets/004f6617-1cfb-45b3-9202-326f9c1ddce3" />
