### PR TITLE
Add 0.23.0 to release schedule

### DIFF
--- a/_data/release-schedule.yml
+++ b/_data/release-schedule.yml
@@ -5,3 +5,6 @@ releases:
   - version: 0.22.0
     plannedDate: July 3, 2026
     milestoneUrl: https://github.com/kroxylicious/kroxylicious/milestone/10
+  - version: 0.23.0
+    plannedDate: August 20, 2026
+    milestoneUrl: https://github.com/kroxylicious/kroxylicious/milestone/28


### PR DESCRIPTION
picked a Thursday, Friday felt good in that we had a whole week to get stuff done and cap it with the release. But of course stuff slipped and the release was incomplete end-of-Friday