### PR TITLE
docs: add 0.23.0 release blog post

### DIFF
--- a/_posts/2026-07-16-release-0_23_0.md
+++ b/_posts/2026-07-16-release-0_23_0.md
@@ -1,0 +1,103 @@
+---
+layout: post
+title: "Kroxylicious release 0.23.0"
+date: 2026-07-16 00:00:00 +0000
+author: "Keith Wall"
+author_url: "https://github.com/k-wall"
+# noinspection YAMLSchemaValidation
+categories: blog kroxylicious-proxy releases
+tags: [ "releases", "kroxylicious-proxy" ]
+---
+
+Kroxylicious 0.23.0 has snapped into existence!
+This release delivers the first preview of our Dynamic Routing runtime, adds PEM key material support to the KMS integrations, and improves multi-tenancy for both CipherTrust Manager and the Kubernetes operator.
+Check out the full [Changelog](https://github.com/kroxylicious/kroxylicious/blob/main/CHANGELOG.md#0230) for everything including deprecations, changes, and removals.
+
+Here are the highlights:
+
+### Preview: Dynamic Routing API
+
+The headline feature is the arrival of the Dynamic Routing runtime.
+We've been snapping at this one for a while — the [design proposal](https://github.com/kroxylicious/design/blob/main/proposals/070-routing-api.md) was accepted earlier this year, we blogged about a [proof of concept](https://kroxylicious.io/blog/topic-routing/), and in 0.22.0 we published the routing interfaces.
+Now the runtime engine is here.
+
+Implement a `RouterFactory` to dispatch requests from a single client connection to multiple upstream clusters based on request content.
+Fan-out requests via `RouterContext.sendRequest()` with in-order response delivery guaranteed.
+Wire routers into virtual clusters via the new top-level `routerDefinitions` configuration:
+
+```yaml
+routerDefinitions:
+  - name: my-router
+    type: com.example.MyRouterFactory
+    config: {}
+
+virtualClusters:
+  - name: multi-cluster
+    target:
+      cluster: default-cluster
+      router: my-router
+```
+
+This is a **preview feature** — opt in by setting the `KROXYLICIOUS_UNLOCK_ROUTING=true` environment variable.
+A warning is emitted at startup when routing is active.
+Note that we don't ship a Router implementation yet — this release is for developers building their own.
+Router and cluster definitions are hot-reload compatible, so routers can be reconfigured without restarting the proxy.
+
+### PEM Key Material for KMS Integrations
+
+A long-standing request (this one goes all the way back to [#933](https://github.com/kroxylicious/kroxylicious/issues/933)!) is finally hatched: the KMS integrations now support PEM format key material for TLS trust and client identity.
+PKCS#1 and PKCS#8 private key formats are both supported.
+This means you no longer need to convert your PEM certificates into PKCS#12 keystores before configuring upstream TLS for your KMS provider.
+
+As part of this work, BouncyCastle has been removed as a production dependency of the proxy.
+If your plugins or deployment relied on BouncyCastle being present on the classpath at runtime, you'll need to add it explicitly.
+
+### CipherTrust Manager Multi-Tenant Support
+
+The CipherTrust Manager KMS plugin now supports an optional `domain` field in `userCredentials`.
+When set, the password-grant token request is scoped to that domain, enabling multi-tenant CipherTrust deployments where different virtual clusters authenticate against different CipherTrust domains:
+
+```yaml
+kms: CipherTrustKmsService
+kmsConfig:
+  endpointUrl: https://ctm.example.com
+  userCredentials:
+    username: myuser
+    password:
+      passwordFile: /path/to/password
+    domain: my-tenant-domain
+```
+
+### Cross-Namespace Strimzi References
+
+[Rafael Reia](https://github.com/RafaelReia) contributed support for cross-namespace Strimzi Kafka references.
+`KafkaService.spec.strimziKafkaRef.namespace` can now point to a Strimzi `Kafka` cluster in any watched namespace, not just the namespace of the `KafkaService` itself.
+This is particularly useful for organisations that separate their Kafka infrastructure and proxy configurations into different namespaces.
+
+### Operator: Configurable Reconciliation Interval
+
+The operator now exposes the JOSDK periodic reconciliation interval for configuration.
+This gives operators fine-grained control over how frequently the operator reconciles custom resources, which can be useful for tuning behaviour in large clusters or when working with external systems that may lag behind the desired state.
+
+### Bug Fixes
+
+A couple of runtime fixes tighten up connection lifecycle management:
+- Channels that had not yet reached the Forwarding state were leaked when a virtual cluster drained on shutdown ([#4309](https://github.com/kroxylicious/kroxylicious/pull/4309)).
+- Outbound connections are now correctly closed when the channel is already inactive at close time ([#4324](https://github.com/kroxylicious/kroxylicious/pull/4324)).
+
+### Community Contributions
+
+This release included commits from:
+
+[AdityaThakur1998](https://github.com/AdityaThakur1998), [Dahyun Woo](https://github.com/dahyvuun), [DeCluttered](https://github.com/Decluttered), [Geonhyeon Kim](https://github.com/gggeon96), Keith Wall, [M Clavo](https://github.com/MClavo), [Rafael Reia](https://github.com/RafaelReia), Robert Young, Sam Barker, Tom Bentley, [Urjit Patel](https://github.com/Uzziee)
+
+Thank you all!
+
+### Artefacts
+
+Binary distributions and container images are available on the [download](https://kroxylicious.io/download/0.23.0/) page.
+
+### Feedback
+
+We'd love to hear from you! Whether you're kicking the tyres, running Kroxylicious in production, or just find the project interesting — drop by and say hello.
+You can reach us through [Slack](https://kroxylicious.slack.com), [GitHub](https://github.com/kroxylicious/kroxylicious/issues) or even [bsky](https://bsky.app/profile/kroxylicious.io), or tell us in person on one of our upcoming [community calls]({% link join-us/community-call/index.md %}).

--- a/_posts/2026-07-16-release-0_23_0.md
+++ b/_posts/2026-07-16-release-0_23_0.md
@@ -12,7 +12,7 @@ tags: [ "releases", "kroxylicious-proxy" ]
 Kroxylicious 0.23.0 has snapped🐊 into existence!
 
 This release adds PEM key material support to the KMS integrations, and adds support for multi-tenancy in the Thales Cipher Trust Manager integration.
-Meanwhile, somewhere below the waterline, Router API and Router incubation continues.
+Router API integration work continues in incubation.
 
 Check out the full [Changelog](https://github.com/kroxylicious/kroxylicious/blob/main/CHANGELOG.md#0230) for everything including deprecations, changes, and removals.
 
@@ -21,7 +21,7 @@ Here are the highlights:
 ### PEM Key Material for KMS Integrations
 
 A long-standing request (this one goes all the way back to [#933](https://github.com/kroxylicious/kroxylicious/issues/933)!) is finally hatched: the KMS integrations now support PEM format key material for TLS trust and client identity. PKCS#1 and PKCS#8 private key formats are both supported.
-This means you no longer need to convert your PEM certificates into PKCS#12 keystores before configuring TLS for your KMS provider.
+You can configure TLS for your KMS provider directly from PEM certificates, without converting to PKCS#12 keystores first.
 
 ### CipherTrust Manager Multi-Tenant Support
 
@@ -47,12 +47,12 @@ If you use client certificate based authentication, domains are supported too.
 `KafkaService.spec.strimziKafkaRef.namespace` can now point to a Strimzi `Kafka` cluster in any watched namespace, not just the namespace of the `KafkaService` itself.
 This is particularly useful for organisations that separate their Kafka infrastructure and proxy configurations into different namespaces.
 
-### Incubation continues: Router API Routing Integration 
+### Router API Integration 
 
-We've continued to work away at integrating the [Router API](https://github.com/kroxylicious/design/blob/main/proposals/070-routing-api.md) into the heart of the proxy.
-There's now the ability for a `RouterFactory` to create a `Router` that can fanout requests (`RouterContext.sendRequest()`) from a single client connection to multiple upstream clusters based on request content.
+We continued integrating the [Router API](https://github.com/kroxylicious/design/blob/main/proposals/070-routing-api.md) into the heart of the proxy.
+A `RouterFactory` can now create a `Router` that fans out requests (`RouterContext.sendRequest()`) from a single client connection to multiple upstream clusters based on request content.
 
-This is still an incubating feature and definitely not ready to go anywhere near production, but if you're curious unlock the feature flag `KROXYLICIOUS_UNLOCK_ROUTING=true` (environment variable) and get routing!  We'd love to hear your feedback.
+This is still an incubating feature and not ready for production, but if you're curious, unlock the feature flag `KROXYLICIOUS_UNLOCK_ROUTING=true` (environment variable) and get routing! We'd love to hear your feedback.
 
 ### Community Contributions
 
@@ -64,9 +64,8 @@ Thank you all!
 
 ### Artefacts
 
-Binary distributions and container images are available on the [download](https://kroxylicious.io/download/0.23.0/) page.
+Download binary distributions and container images from the [download](https://kroxylicious.io/download/0.23.0/) page.
 
 ### Feedback
 
-We'd love to hear from you! Whether you're kicking the tyres, running Kroxylicious in production, or just find the project interesting — drop by and say hello.
-You can reach us through [Slack](https://kroxylicious.slack.com), [GitHub](https://github.com/kroxylicious/kroxylicious/issues) or even [bsky](https://bsky.app/profile/kroxylicious.io), or tell us in person on one of our upcoming [community calls]({% link join-us/community-call/index.md %}).
+Drop by and say hello on [Slack](https://kroxylicious.slack.com), [GitHub](https://github.com/kroxylicious/kroxylicious/issues), or [bsky](https://bsky.app/profile/kroxylicious.io). You can also join us in person at a [community call]({% link join-us/community-call/index.md %}).

--- a/_posts/2026-07-16-release-0_23_0.md
+++ b/_posts/2026-07-16-release-0_23_0.md
@@ -9,48 +9,19 @@ categories: blog kroxylicious-proxy releases
 tags: [ "releases", "kroxylicious-proxy" ]
 ---
 
-Kroxylicious 0.23.0 has snapped into existence!
-This release delivers the first preview of our Dynamic Routing runtime, adds PEM key material support to the KMS integrations, and improves multi-tenancy for both CipherTrust Manager and the Kubernetes operator.
+Kroxylicious 0.23.0 has snapped🐊 into existence!
+
+This release adds PEM key material support to the KMS integrations, and adds support for multi-tenancy in the Thales Cipher Trust Manager integration.
+Meanwhile, below the waterline, Router API and Router integration continues.
+
 Check out the full [Changelog](https://github.com/kroxylicious/kroxylicious/blob/main/CHANGELOG.md#0230) for everything including deprecations, changes, and removals.
 
 Here are the highlights:
 
-### Preview: Dynamic Routing API
-
-The headline feature is the arrival of the Dynamic Routing runtime.
-We've been snapping at this one for a while — the [design proposal](https://github.com/kroxylicious/design/blob/main/proposals/070-routing-api.md) was accepted earlier this year, we blogged about a [proof of concept](https://kroxylicious.io/blog/topic-routing/), and in 0.22.0 we published the routing interfaces.
-Now the runtime engine is here.
-
-Implement a `RouterFactory` to dispatch requests from a single client connection to multiple upstream clusters based on request content.
-Fan-out requests via `RouterContext.sendRequest()` with in-order response delivery guaranteed.
-Wire routers into virtual clusters via the new top-level `routerDefinitions` configuration:
-
-```yaml
-routerDefinitions:
-  - name: my-router
-    type: com.example.MyRouterFactory
-    config: {}
-
-virtualClusters:
-  - name: multi-cluster
-    target:
-      cluster: default-cluster
-      router: my-router
-```
-
-This is a **preview feature** — opt in by setting the `KROXYLICIOUS_UNLOCK_ROUTING=true` environment variable.
-A warning is emitted at startup when routing is active.
-Note that we don't ship a Router implementation yet — this release is for developers building their own.
-Router and cluster definitions are hot-reload compatible, so routers can be reconfigured without restarting the proxy.
-
 ### PEM Key Material for KMS Integrations
 
-A long-standing request (this one goes all the way back to [#933](https://github.com/kroxylicious/kroxylicious/issues/933)!) is finally hatched: the KMS integrations now support PEM format key material for TLS trust and client identity.
-PKCS#1 and PKCS#8 private key formats are both supported.
-This means you no longer need to convert your PEM certificates into PKCS#12 keystores before configuring upstream TLS for your KMS provider.
-
-As part of this work, BouncyCastle has been removed as a production dependency of the proxy.
-If your plugins or deployment relied on BouncyCastle being present on the classpath at runtime, you'll need to add it explicitly.
+A long-standing request (this one goes all the way back to [#933](https://github.com/kroxylicious/kroxylicious/issues/933)!) is finally hatched: the KMS integrations now support PEM format key material for TLS trust and client identity. PKCS#1 and PKCS#8 private key formats are both supported.
+This means you no longer need to convert your PEM certificates into PKCS#12 keystores before configuring TLS for your KMS provider.
 
 ### CipherTrust Manager Multi-Tenant Support
 
@@ -68,22 +39,20 @@ kmsConfig:
     domain: my-tenant-domain
 ```
 
+If you use client certificate based authentication, domains are supported too.
+
 ### Cross-Namespace Strimzi References
 
 [Rafael Reia](https://github.com/RafaelReia) contributed support for cross-namespace Strimzi Kafka references.
 `KafkaService.spec.strimziKafkaRef.namespace` can now point to a Strimzi `Kafka` cluster in any watched namespace, not just the namespace of the `KafkaService` itself.
 This is particularly useful for organisations that separate their Kafka infrastructure and proxy configurations into different namespaces.
 
-### Operator: Configurable Reconciliation Interval
+### Incubation continues: Router API Routing Integration 
 
-The operator now exposes the JOSDK periodic reconciliation interval for configuration.
-This gives operators fine-grained control over how frequently the operator reconciles custom resources, which can be useful for tuning behaviour in large clusters or when working with external systems that may lag behind the desired state.
+We've continued to work away at integrating the [Router API](https://github.com/kroxylicious/design/blob/main/proposals/070-routing-api.md) into the heart of the proxy.
+There's now the ability for a `RouterFactory` to create a `Router` that can fanout requests `RouterContext.sendRequest()`) from a single client connection to multiple upstream clusters based on request content.
 
-### Bug Fixes
-
-A couple of runtime fixes tighten up connection lifecycle management:
-- Channels that had not yet reached the Forwarding state were leaked when a virtual cluster drained on shutdown ([#4309](https://github.com/kroxylicious/kroxylicious/pull/4309)).
-- Outbound connections are now correctly closed when the channel is already inactive at close time ([#4324](https://github.com/kroxylicious/kroxylicious/pull/4324)).
+This is still an incubating feature and definitely not ready to go anywhere near production, but if you curious unlock the feature flag `KROXYLICIOUS_UNLOCK_ROUTING=true` (environment variable) and get routing!  We'd love to hear your feedback.
 
 ### Community Contributions
 

--- a/_posts/2026-07-16-release-0_23_0.md
+++ b/_posts/2026-07-16-release-0_23_0.md
@@ -50,9 +50,9 @@ This is particularly useful for organisations that separate their Kafka infrastr
 ### Incubation continues: Router API Routing Integration 
 
 We've continued to work away at integrating the [Router API](https://github.com/kroxylicious/design/blob/main/proposals/070-routing-api.md) into the heart of the proxy.
-There's now the ability for a `RouterFactory` to create a `Router` that can fanout requests `RouterContext.sendRequest()`) from a single client connection to multiple upstream clusters based on request content.
+There's now the ability for a `RouterFactory` to create a `Router` that can fanout requests (`RouterContext.sendRequest()`) from a single client connection to multiple upstream clusters based on request content.
 
-This is still an incubating feature and definitely not ready to go anywhere near production, but if you curious unlock the feature flag `KROXYLICIOUS_UNLOCK_ROUTING=true` (environment variable) and get routing!  We'd love to hear your feedback.
+This is still an incubating feature and definitely not ready to go anywhere near production, but if you're curious unlock the feature flag `KROXYLICIOUS_UNLOCK_ROUTING=true` (environment variable) and get routing!  We'd love to hear your feedback.
 
 ### Community Contributions
 

--- a/_posts/2026-07-16-release-0_23_0.md
+++ b/_posts/2026-07-16-release-0_23_0.md
@@ -12,7 +12,7 @@ tags: [ "releases", "kroxylicious-proxy" ]
 Kroxylicious 0.23.0 has snapped🐊 into existence!
 
 This release adds PEM key material support to the KMS integrations, and adds support for multi-tenancy in the Thales Cipher Trust Manager integration.
-Meanwhile, below the waterline, Router API and Router integration continues.
+Meanwhile, somewhere below the waterline, Router API and Router incubation continues.
 
 Check out the full [Changelog](https://github.com/kroxylicious/kroxylicious/blob/main/CHANGELOG.md#0230) for everything including deprecations, changes, and removals.
 


### PR DESCRIPTION
## Summary

- Add release blog post for Kroxylicious 0.23.0
- Highlights: Dynamic Routing API preview, PEM key material for KMS, CipherTrust Manager multi-tenant support, cross-namespace Strimzi refs, configurable reconciliation interval, bug fixes

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>