### PR TITLE
Add 0.24.0 and 0.25.0 to release schedule

### DIFF
--- a/_data/release-schedule.yml
+++ b/_data/release-schedule.yml
@@ -8,3 +8,9 @@ releases:
   - version: 0.23.0
     plannedDate: July 16, 2026
     milestoneUrl: https://github.com/kroxylicious/kroxylicious/milestone/28
+  - version: 0.24.0
+    plannedDate: August 27, 2026
+    milestoneUrl: https://github.com/kroxylicious/kroxylicious/milestone/29
+  - version: 0.23.0
+    plannedDate: October 8, 2026
+    milestoneUrl: https://github.com/kroxylicious/kroxylicious/milestone/31

--- a/_data/release-schedule.yml
+++ b/_data/release-schedule.yml
@@ -1,18 +1,21 @@
 releases:
   - version: 0.21.0
     plannedDate: May 15, 2026
-    milestoneUrl: https://github.com/kroxylicious/kroxylicious/milestone/27
+    milestoneNumber: 27
+    projectNumber: 13
   - version: 0.22.0
     plannedDate: July 3, 2026
-    milestoneUrl: https://github.com/kroxylicious/kroxylicious/milestone/10
+    milestoneNumber: 10
+    projectNumber: 12
   - version: 0.23.0
     plannedDate: July 16, 2026
-    milestoneUrl: https://github.com/kroxylicious/kroxylicious/milestone/28
+    milestoneNumber: 28
+    projectNumber: 17
   - version: 0.24.0
     plannedDate: August 27, 2026
-    milestoneUrl: https://github.com/kroxylicious/kroxylicious/milestone/29
+    milestoneNumber: 29
     projectNumber: 19
   - version: 0.25.0
     plannedDate: October 8, 2026
-    milestoneUrl: https://github.com/kroxylicious/kroxylicious/milestone/31
+    milestoneNumber: 31
     projectNumber: 20

--- a/_data/release-schedule.yml
+++ b/_data/release-schedule.yml
@@ -11,6 +11,8 @@ releases:
   - version: 0.24.0
     plannedDate: August 27, 2026
     milestoneUrl: https://github.com/kroxylicious/kroxylicious/milestone/29
-  - version: 0.23.0
+    projectNumber: 19
+  - version: 0.25.0
     plannedDate: October 8, 2026
     milestoneUrl: https://github.com/kroxylicious/kroxylicious/milestone/31
+    projectNumber: 20

--- a/release-schedule.markdown
+++ b/release-schedule.markdown
@@ -27,7 +27,7 @@ permalink: /release-schedule/
             <tr>
               <td>Kroxylicious {{ release.version }}</td>
               <td>{{ release.plannedDate }}</td>
-              <td><a href="{{ release.milestoneUrl }}">{{ release.version }}</a></td>
+              <td><a href="https://github.com/kroxylicious/kroxylicious/milestone/{{ release.milestoneNumber }}">{{ release.version }}</a></td>
               <td>
                 {%- if release.projectNumber -%}
                 <a href="https://github.com/orgs/kroxylicious/projects/{{ release.projectNumber }}">{{ release.version }}</a>

--- a/release-schedule.markdown
+++ b/release-schedule.markdown
@@ -17,6 +17,7 @@ permalink: /release-schedule/
               <th scope="col">Release</th>
               <th scope="col">Planned Release Date</th>
               <th scope="col">Milestone</th>
+              <th scope="col">Project Board</th>
               <th scope="col">Status</th>
             </tr>
           </thead>
@@ -27,6 +28,13 @@ permalink: /release-schedule/
               <td>Kroxylicious {{ release.version }}</td>
               <td>{{ release.plannedDate }}</td>
               <td><a href="{{ release.milestoneUrl }}">{{ release.version }}</a></td>
+              <td>
+                {%- if release.projectNumber -%}
+                <a href="https://github.com/orgs/kroxylicious/projects/{{ release.projectNumber }}">{{ release.version }}</a>
+                {%- else -%}
+                -
+                {%- endif -%}
+              </td>
               <td>
                 {%- if site.data.release[underscored_version] -%}
                 <span class="badge bg-success">Released</span>


### PR DESCRIPTION
Also adds Project Board links to the table.

<img width="1311" height="285" alt="Screenshot From 2026-07-17 18-59-11" src="https://github.com/user-attachments/assets/874390b3-41a1-4195-803d-6cd5e57c180c" />
